### PR TITLE
feat(changelog): support empty compare_url_format

### DIFF
--- a/src/conventional/changelog.rs
+++ b/src/conventional/changelog.rs
@@ -109,8 +109,9 @@ impl<'a> ContextBuilder<'a> {
             .handlebars
             .render("release_commit_message_format", &context_base)?;
         let user_url_format = self.handlebars.render("user_url_format", &context_base)?;
-        let link_compare =
-            !context_base.current_tag.is_empty() && !context_base.previous_tag.is_empty();
+        let link_compare = !compare_url_format.is_empty()
+            && !context_base.current_tag.is_empty()
+            && !context_base.previous_tag.is_empty();
         Ok(Context {
             context: context_base,
             compare_url_format,


### PR DESCRIPTION
It would be useful to be able to omit the compare url but when `compare_url_format` is an empty string, headers are generated with the format:
```
 ## [v0.1.0]() (2020-02-12)
```
This commit removes the empty link.