### PR TITLE
feat(changelog): make commit body available in template context

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -131,11 +131,12 @@ impl<'a> ChangeLogTransformer<'a> {
                 let date = chrono::NaiveDateTime::from_timestamp(commit.time().seconds(), 0).date();
                 let scope = conv_commit.scope;
                 let subject = conv_commit.description;
+                let body = conv_commit.body;
                 let short_hash = hash[..7].into();
                 let mut references = Vec::new();
-                if let Some(body) = conv_commit.body {
-                    references.extend(self.re_references.captures_iter(body.as_str()).map(
-                        |refer| Reference {
+                if let Some(body) = &body {
+                    references.extend(self.re_references.captures_iter(body).map(|refer| {
+                        Reference {
                             // TODO action (the word before?)
                             action: None,
                             owner: "",
@@ -143,8 +144,8 @@ impl<'a> ChangeLogTransformer<'a> {
                             prefix: refer[1].to_owned(),
                             issue: refer[2].to_owned(),
                             raw: refer[0].to_owned(),
-                        },
-                    ));
+                        }
+                    }));
                 }
                 references.extend(conv_commit.footers.iter().flat_map(|footer| {
                     self.re_references
@@ -163,6 +164,7 @@ impl<'a> ChangeLogTransformer<'a> {
                     date,
                     scope,
                     subject,
+                    body,
                     short_hash,
                     references,
                 };

--- a/src/conventional/changelog.rs
+++ b/src/conventional/changelog.rs
@@ -38,6 +38,7 @@ pub(crate) struct CommitContext<'a> {
     pub(crate) hash: String,
     pub(crate) date: NaiveDate,
     pub(crate) subject: String,
+    pub(crate) body: Option<String>,
     pub(crate) scope: Option<String>,
     pub(crate) short_hash: String,
     pub(crate) references: Vec<Reference<'a>>,


### PR DESCRIPTION
Make the commit body available in the template context, so that it can be used for more detailed release notes in custom templates.