### PR TITLE
Statically Linked Binary in multi-arch docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: "docker"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+  workflow_dispatch:
+jobs:
+  bake:
+    name: "build and pushing convco docker image"
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: "Login to Docker Container Repository"
+        run: echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: "build docker image"
+        shell: bash
+        run: |
+          set -ex ;
+          docker buildx use "convco" \
+          || docker buildx create --use --name "convco" --driver docker-container ;
+          docker buildx bake --builder convco ;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: |
           set -ex ;
-          export TAG=$(git describe --tags --abbrev=0 | sed 's/v//g') 
+          export TAG=$(git describe --tags --abbrev=0 | sed 's/v//g') ;
           docker buildx use "convco" \
           || docker buildx create --use --name "convco" --driver docker-container ;
           docker buildx bake --builder convco ;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   bake:
     name: "build and pushing convco docker image"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,8 @@
 name: "docker"
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
-  workflow_dispatch:
+    tags:
+      - 'v*.*.*'
 jobs:
   bake:
     name: "build and pushing convco docker image"
@@ -27,6 +26,7 @@ jobs:
         shell: bash
         run: |
           set -ex ;
+          export TAG=$(git describe --tags --abbrev=0 | sed 's/v//g') 
           docker buildx use "convco" \
           || docker buildx create --use --name "convco" --driver docker-container ;
           docker buildx bake --builder convco ;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: |
           set -ex ;
-          export TAG=$(git describe --tags --abbrev=0 | sed 's/v//g') ;
+          export TAG=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev | tr -d 'v' | sed 's/master/latest/') ;
           docker buildx use "convco" \
           || docker buildx create --use --name "convco" --driver docker-container ;
           docker buildx bake --builder convco ;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: "docker"
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,8 @@ RUN                                                                             
   && strip /workspace/convco                                                                                                 \
   && upx /workspace/convco                                                                                                   \
   && /workspace/convco --version
-FROM scratch
+FROM alpine:3.14
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 COPY --chmod=0755 --from=compression-layer /workspace/convco /entrypoint
 WORKDIR /workspace
 VOLUME /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,122 @@
-FROM rust:alpine as builder
-RUN apk add clang musl-dev openssl-dev cmake make
-
-COPY . /tmp
-WORKDIR /tmp
-
-RUN cargo --version
-RUN cargo build --release
-
-FROM alpine as base
-COPY --from=builder /tmp/target/release/convco /usr/bin/convco
-
-ENTRYPOINT [ "convco" ]
+# syntax = docker/dockerfile-upstream:master-labs
+#-*-mode:dockerfile;indent-tabs-mode:nil;tab-width:2;coding:utf-8-*-
+# vi: ft=dockerfile tabstop=2 shiftwidth=2 softtabstop=2 expandtab:
+FROM alpine:3.14 AS upx-downloader
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN                                                                                                                          \
+  apk add --no-cache                                                                                                         \
+    curl=7.78.0-r0                                                                                                           \
+    jq=1.6-r1                                                                                                                \
+    xz=5.2.5-r0 ;
+ARG REPO="upx/upx"
+ARG LATEST_RELEASE_ENDPOINT="https://api.github.com/repos/${REPO}/releases/latest"
+RUN                                                                                                                          \
+  tag_name="$(curl -sL ${LATEST_RELEASE_ENDPOINT} | jq -r '.tag_name')";                                                     \
+  architecture="$(apk --print-arch)";                                                                                        \
+  case "$architecture" in                                                                                                    \
+    x86_64|amd64)                                                                                                            \
+      architecture="amd64"                                                                                                   \
+    ;;                                                                                                                       \
+    aarch64)                                                                                                                 \
+      architecture="arm64"                                                                                                   \
+    ;;                                                                                                                       \
+    *)                                                                                                                       \
+      echo >&2 "[ WARN ] compression utilities are not available: $architecture";                                            \
+      exit 0                                                                                                                 \
+    ;;                                                                                                                       \
+  esac ;                                                                                                                     \
+  version="$(echo ${tag_name} | sed 's/v//g')";                                                                              \
+  download_url="https://github.com/upx/upx/releases/download/${tag_name}/upx-${version}-${architecture}_linux.tar.xz";       \
+  rm -rf                                                                                                                     \
+    /tmp/{upx.tar,upx.tar.xz}                                                                                                \
+    /usr/local/bin/upx                                                                                                       \
+  && echo "$download_url" > /tmp/dl                                                                                          \
+  && curl -fsSLo /tmp/upx.tar.xz "${download_url}"                                                                           \
+  && xz -d -c /tmp/upx.tar.xz                                                                                                \
+  | tar                                                                                                                      \
+    -xOf - upx-${version}-${architecture}_linux/upx > /upx
+FROM alpine:3.14 AS base
+# ────────────────────────────────────────────────────────────────────────────────
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+# ────────────────────────────────────────────────────────────────────────────────
+RUN                                                                                                                          \
+  apk add --no-cache                                                                                                         \
+  build-base=0.5-r2                                                                                                          \
+  cmake=3.20.3-r0                                                                                                            \
+  curl=7.78.0-r0                                                                                                             \
+  libgit2-static=1.1.0-r2                                                                                                    \
+  musl-dev=1.2.2-r3                                                                                                          \
+  openssl-dev=1.1.1l-r0                                                                                                      \
+  openssl-libs-static=1.1.1l-r0
+# ────────────────────────────────────────────────────────────────────────────────
+FROM base AS builder-layer
+ARG RUST_VERSION="1.54.0"
+ARG RUSTUP_URL="https://sh.rustup.rs"
+ENV RUSTUP_HOME="/usr/local/rustup"
+ENV CARGO_HOME="/usr/local/cargo"
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+ENV RUST_VERSION "${RUST_VERSION}"
+RUN                                                                                                                          \
+  case "$(apk --print-arch)" in                                                                                              \
+    x86_64 | aarch64 )                                                                                                       \
+      true                                                                                                                   \
+    ;;                                                                                                                       \
+    *)                                                                                                                       \
+    exit 1                                                                                                                   \
+    ;;                                                                                                                       \
+  esac;                                                                                                                      \
+  curl --proto '=https' --tlsv1.2 -fSsl "${RUSTUP_URL}" | sh -s -- -y                                                        \
+  --no-modify-path                                                                                                           \
+  --profile minimal                                                                                                          \
+  --default-toolchain "${RUST_VERSION}"                                                                                      \
+  --default-host "$(apk --print-arch)-unknown-linux-musl"                                                                    \
+  && chmod -R a+w "${RUSTUP_HOME}" "${CARGO_HOME}"                                                                           \
+  && rustup --version                                                                                                        \
+  && cargo --version                                                                                                         \
+  && rustc --version                                                                                                         \
+  && rustup toolchain install "stable-$(apk --print-arch)-unknown-linux-musl"
+# ────────────────────────────────────────────────────────────────────────────────
+COPY <<-"EOT" /usr/local/cargo/config
+[target.x86_64-unknown-linux-musl]
+  rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-unknown-linux-musl]
+  rustflags = ["-C", "target-feature=+crt-static"]
+EOT
+# ────────────────────────────────────────────────────────────────────────────────
+ENV OPENSSL_STATIC=yes
+ENV OPENSSL_LIB_DIR="/usr/lib"
+ENV OPENSSL_INCLUDE_DIR="/usr/include"
+WORKDIR "/workspace"
+COPY . /workspace
+RUN                                                                                                                          \
+  --mount=type=cache,target=/root/.cargo                                                                                     \
+  --mount=type=cache,target=/usr/local/cargo/registry                                                                        \
+  [ "$(apk --print-arch)" == "aarch64" ] && export CFLAGS="-mno-outline-atomics" ;                                           \
+  rustup run stable cargo build                                                                                              \
+    --release                                                                                                                \
+    --jobs "$(nproc)"                                                                                                        \
+    --target "$(apk --print-arch)-unknown-linux-musl"                                                                        \
+  && if [[ ! -z $(readelf -d "/workspace/target/$(apk --print-arch)-unknown-linux-musl/release/convco" | grep NEED) ]]; then \
+    if ldd "/workspace/target/$(apk --print-arch)-unknown-linux-musl/release/convco" > /dev/null 2>&1; then                  \
+      echo >&2 "*** '/workspace/target/$(apk --print-arch)-unknown-linux-musl/release/convco' was not linked statically" ;   \
+      exit 1 ;                                                                                                               \
+    fi                                                                                                                       \
+  fi                                                                                                                         \
+  && mv "/workspace/target/$(apk --print-arch)-unknown-linux-musl/release/convco" /convco
+FROM base AS compression-layer
+COPY --chmod=0755 --from=upx-downloader /upx /usr/local/bin/upx
+RUN                                                                                                                          \
+  upx --version                                                                                                              \
+WORKDIR /workspace
+COPY --chmod=0755 --from=builder-layer /convco /workspace/convco
+RUN                                                                                                                          \
+  /workspace/convco --version                                                                                                \
+  && strip /workspace/convco                                                                                                 \
+  && upx /workspace/convco                                                                                                   \
+  && /workspace/convco --version
+FROM scratch
+COPY --chmod=0755 --from=compression-layer /workspace/convco /entrypoint
+WORKDIR /workspace
+VOLUME /workspace
+ENTRYPOINT [ "/entrypoint" ]
 CMD [ "check" ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,38 @@
+#-*-mode:hcl;indent-tabs-mode:nil;tab-width:2;coding:utf-8-*-
+# vi: ft=hcl tabstop=2 shiftwidth=2 softtabstop=2 expandtab:
+
+# [ NOTE ] => clean up buildx builders
+# docker buildx ls | awk '$2 ~ /^docker(-container)*$/{print $1}' | xargs -r -I {} docker buildx rm {}
+# [ NOTE ] create a builder for this file
+# docker buildx create --use --name "convco" --driver docker-container
+# [ NOTE ] run build without pushing to dockerhub
+# LOCAL=true docker buildx bake --builder convco
+
+variable "LOCAL" {default=false}
+variable "ARM64" {default=true}
+variable "AMD64" {default=true}
+variable "TAG" {default=""}
+variable "IMAGE_NAME" {default="convco/convco"}
+group "default" {
+  targets = [
+    "convco"
+  ]
+}
+# LOCAL=true docker buildx bake --builder convco convco
+# LOCAL=true ARM64=false AMD64=true docker buildx bake --builder convco convco
+# LOCAL=true ARM64=true AMD64=false docker buildx bake --builder convco convco
+target "convco" {
+  context="."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:latest",
+    notequal("",TAG) ? "${IMAGE_NAME}:${TAG}": "",
+  ]
+  platforms = [
+    equal(AMD64,true) ?"linux/amd64":"",
+    equal(ARM64,true) ?"linux/arm64":"",
+  ]
+  cache-from = ["type=registry,ref=${IMAGE_NAME}:cache"]
+  cache-to   = [equal(LOCAL,false) ? "type=registry,mode=max,ref=${IMAGE_NAME}:cache" : ""]
+  output     = [equal(LOCAL,true) ? "type=docker" : "type=registry"]
+}


### PR DESCRIPTION
# Pull Request

## Summary

- Created a multi-arch Docker image :
- Supports `x86_64` and `aarch64` architecture
- The binary is statically linked 
- Minimal Docker image
  - Compressed
  - Final layer is based on `scratch` 
- Image caching has been included for speeding up build's in CI/CD pipelines
- `buildx` plugin with the new `HCL` frontend is used for building the image.
- Github Actions workflow is included

## notes

- by default, the image name is set to `convco/convco`. to change this value, set the `IMAGE_NAME` environment variable in
Github actions pipeline
- [x] To push the image to Dockerhub, you must ensure `DOCKER_USERNAME` and `DOCKER_PASSWORD` are set in the repositories secrets.
- [x] the HCL file supports tagging the image. To add a tag, update the workflow file and set the `TAG` environment variable.

## Closing issues

Refs: #23