### PR TITLE
feat(changelog): add skip empty flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,8 @@ pub struct ChangelogCommand {
     pub prefix: String,
     #[structopt(default_value = "HEAD")]
     pub rev: String,
+    #[structopt(short, long)]
+    pub skip_empty: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -325,12 +325,16 @@ impl Command for ChangelogCommand {
                     let from = &w[0];
                     let to = &w[1];
                     let context = transformer.transform(from, to)?;
-                    writer.write_template(&context)?;
+                    if !self.skip_empty || !context.context.commit_groups.is_empty() {
+                        writer.write_template(&context)?;
+                    }
                 }
             }
             None => {
                 let context = transformer.transform(&Rev("HEAD", None), &Rev("", None))?;
-                writer.write_template(&context)?;
+                if !self.skip_empty || !context.context.commit_groups.is_empty() {
+                    writer.write_template(&context)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
If a release contains no sections to display `--skip-empty` can be used to not show the release in the changelog.
This is useful if old commits were not conventional or if you configured to hide some types and the release contains no sections.

Refs: #30