### PR TITLE
fix(commit): do not require save for editor

### DIFF
--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -114,7 +114,7 @@ fn read_description(
 
 fn edit_message(msg: &str) -> Result<String, Error> {
     Ok(dialoguer::Editor::new()
-        .require_save(true)
+        .require_save(false)
         .edit(msg)?
         .unwrap_or_default()
         .lines()


### PR DESCRIPTION
In `vim` the editor can be closed using `:wq` `:x` or `ZZ`.
The latter two will not save the buffer if nothing changed.
This should not be an issue if the author is happy with the conventional commit message and doesnot want to add a body.