### PR TITLE
fix(commit): ensure the cursor re-appears when interrupting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -149,6 +149,8 @@ name = "convco"
 version = "0.3.7"
 dependencies = [
  "chrono",
+ "console",
+ "ctrlc",
  "dialoguer",
  "git2",
  "handlebars",
@@ -159,6 +161,16 @@ dependencies = [
  "structopt",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -326,9 +338,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libgit2-sys"
@@ -402,6 +414,28 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ structopt = "0.3.25"
 url = "2.2.2"
 dialoguer = "0.9.0"
 thiserror = "1.0.30"
+ctrlc = "3.2.1"
+console = "0.15.0"
 
 [build-dependencies]
 structopt = "0.3.25"

--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -178,6 +178,13 @@ impl Dialog {
         let types = config.types.as_slice();
         let scope_regex = Regex::new(config.scope_regex.as_str()).expect("valid scope regex");
 
+        // make sure that the cursor re-appears when interrupting
+        ctrlc::set_handler(move || {
+            let term = console::Term::stdout();
+            let _ = term.show_cursor();
+        })
+        .unwrap();
+
         // type
         let current_type = dialog.r#type.as_str();
         match (r#type.as_ref(), current_type) {


### PR DESCRIPTION
Hey @hdevalke,

First, thanks for this great tool!
I found a small bug in interactive mode. As the fix is pretty straightforward, here is a PR.

**Bug description**
The cursor disappears after interrupting the `commit` command (`ctrl+c`).

<p align="center">
  <a href="https://asciinema.org/a/AeMYRcVpkkdnyPkT2djdoy5qr">
    <img src="https://asciinema.org/a/AeMYRcVpkkdnyPkT2djdoy5qr.svg" width="400" />
  </a>
</p>

**To Reproduce**
Steps to reproduce the behavior:
1. Run `convco commit`
2. Hit `ctrl+c`
4. The cursor does not re-appear

**Additional context**
This is an issue that [has already been reported to `dialoguer`](https://github.com/mitsuhiko/dialoguer/issues/77). We need to handle this manually by intercepting the `SIGINT` signal and ensure the cursor is visible. This is what this PR is about.

