### PR TITLE
Support monorepo

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,6 +82,9 @@ pub struct ChangelogCommand {
     /// Print hidden sections
     #[clap(long)]
     pub include_hidden_sections: bool,
+    /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
+    #[clap(short = 'P', long)]
+    pub paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,9 @@ pub struct VersionCommand {
     /// Bump to a patch release version, regardless of the conventional commits
     #[clap(long)]
     pub patch: bool,
+    /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
+    #[clap(short = 'P', long)]
+    pub paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -64,6 +64,7 @@ impl VersionCommand {
         let i = revwalk
             .flatten()
             .filter_map(|oid| git.find_commit(oid).ok())
+            .filter(|commit| git.commit_updates_any_path(commit, &self.paths))
             .filter_map(|commit| commit.message().and_then(|msg| parser.parse(msg).ok()));
 
         let mut major = false;


### PR DESCRIPTION
I was testing convco with a monorepo. I need that only the commits that update one folder to be used to calculate the next version or changelog. So I added a new argument --file (multiple) to allow filtering commits.

I don't know rust but it seems to work. I hope that it can be useful.