### PR TITLE
feat(commit): use template to format message

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,2 +1,3 @@
 template: "src/conventional/changelog"
 scopeRegex: "changelog|check|commit|version"
+commitTemplate: "src/conventional/commit/message.hbs"

--- a/src/conventional/commit/message.hbs
+++ b/src/conventional/commit/message.hbs
@@ -1,0 +1,8 @@
+{{type}}{{#if scope}}({{scope}}){{/if}}{{#if breaking}}!{{/if}}: {{description}}
+{{body}}
+{{#if breaking_change}}BREAKING CHANGE: {{breaking_change}}{{/if}}
+
+{{#if issues}}Refs: {{#each issues}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}}
+{{#each footers}}
+{{this}}
+{{/each}}

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -62,6 +62,8 @@ pub(crate) struct Config {
     pub(crate) repository: Option<String>,
     /// `template`. An optional template directory. The template should be called `template.hbs`. Partials can be used.
     pub(crate) template: Option<PathBuf>,
+    /// `commitTemplate`. An optional template file for convco commit.
+    pub(crate) commit_template: Option<PathBuf>,
     /// `scopeRegex`. A regex to define possible scopes.
     /// For this project this could be `"changelog|check|commit|version"`.
     /// Defaults to `"[[:alnum:]]+(?:[-_/][[:alnum:]]+)*"`.
@@ -105,6 +107,7 @@ impl Default for Config {
             owner: None,
             repository: None,
             template: None,
+            commit_template: None,
             scope_regex: "[[:alnum:]]+(?:[-_/][[:alnum:]]+)*".to_string(),
             link_compare: true,
             link_references: true,
@@ -412,6 +415,7 @@ mod tests {
                 owner: None,
                 repository: None,
                 template: None,
+                commit_template: None,
                 scope_regex: "[[:alnum:]]+(?:[-_/][[:alnum:]]+)*".to_string(),
                 link_compare: true,
                 link_references: true,


### PR DESCRIPTION
A commit template can be configured in `.versionrc`:

```yaml
commitTemplate: "src/conventional/commit/message.hbs"
```

The binary contains the template at `src/conventional/commit/message.hbs`

Refs: #54