### PR TITLE
feat(changelog): filter max majors/minors/patches

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,9 +79,18 @@ pub struct ChangelogCommand {
     pub rev: String,
     #[clap(short, long)]
     pub skip_empty: bool,
-    /// Limits the number of version tags to add in the changelog
+    /// Limits the number of version tags to add in the changelog.
     #[clap(short, long)]
     pub max_versions: Option<usize>,
+    /// Only print this number of major versions.
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    pub max_minors: u64,
+    /// Only show this number of minor versions.
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    pub max_majors: u64,
+    /// Only show this number of patch versions.
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    pub max_patches: u64,
     /// Do not generate links. Overrides linkReferences and linkCompare in the config.
     #[clap(short, long)]
     pub no_links: bool,

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -325,6 +325,14 @@ impl ChangelogCommand {
                 } else {
                     iter.chain(None)
                 };
+
+                let stop_at_major =
+                    (last_version.version.0.major + 1).saturating_sub(self.max_majors);
+                let stop_at_minor =
+                    (last_version.version.0.minor + 1).saturating_sub(self.max_minors);
+                let stop_at_patch =
+                    (last_version.version.0.patch + 1).saturating_sub(self.max_patches);
+
                 let iter = iter
                     .chain(
                         helper
@@ -332,6 +340,9 @@ impl ChangelogCommand {
                             .into_iter()
                             .rev()
                             .take_while(|v| v.tag != rev_stop)
+                            .take_while(|v| v.version.major() >= stop_at_major)
+                            .take_while(|v| v.version.minor() >= stop_at_minor)
+                            .take_while(|v| v.version.patch() >= stop_at_patch)
                             .map(|v| v.into()),
                     )
                     .chain(Some(Rev(rev_stop, None)))

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -33,6 +33,10 @@ impl SemVer {
         self.0.major
     }
 
+    pub fn minor(&self) -> u64 {
+        self.0.minor
+    }
+
     pub fn patch(&self) -> u64 {
         self.0.patch
     }


### PR DESCRIPTION
Adds the following options

        --max-majors <MAX_MAJORS>
            Only show this number of minor versions

        --max-minors <MAX_MINORS>
            Only print this number of major versions

        --max-patches <MAX_PATCHES>
            Only show this number of patch versions

Refs: #59