### PR TITLE
feat(check): filter commits made by git revert

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,9 @@ pub struct CheckCommand {
     /// Follow only the first parent
     #[clap(long)]
     pub first_parent: bool,
+    /// Ignore commits created by `git revert` commands
+    #[clap(long)]
+    pub ignore_reverts: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::CheckCommand,
     cmd::Command,
     conventional::{self, Type},
-    git::filter_merge_commits,
+    git::{filter_merge_commits, filter_revert_commits},
     Error,
 };
 
@@ -75,6 +75,7 @@ impl Command for CheckCommand {
             .flatten()
             .flat_map(|oid| repo.find_commit(oid).ok())
             .filter(|commit| filter_merge_commits(commit, merges))
+            .filter(|commit| filter_revert_commits(commit, self.ignore_reverts))
             .take(self.number.unwrap_or(std::usize::MAX))
         {
             total += 1;

--- a/src/git.rs
+++ b/src/git.rs
@@ -118,6 +118,13 @@ pub(crate) fn filter_merge_commits(commit: &git2::Commit, merges: bool) -> bool 
     merges || commit.parent_count() <= 1
 }
 
+pub(crate) fn filter_revert_commits(commit: &git2::Commit, ignore_reverts: bool) -> bool {
+    if ignore_reverts {
+        return commit.message().map(|m| !m.starts_with("Revert \"")).unwrap_or(true)
+    }
+    true
+}
+
 /// Build a hashmap that contains Commit `Oid` as key and `Version` as value.
 /// Can be used to easily walk a graph and check if it is a version.
 fn make_oid_version_map(repo: &Repository, prefix: &str) -> HashMap<Oid, VersionAndTag> {


### PR DESCRIPTION
Adds the option: `--ignore-reverts``

If turned on, git commit messages matches on regex `(?i)revert` are ignored.

Closes https://github.com/convco/convco/issues/80

---
For example:
```
convco check origin/master..HEAD
FAIL  c790e42  first line doesn't match `<type>[optional scope]: <description>`  Revert "just a test"

convco check origin/master..HEAD --ignore-reverts
no commits checked
```