### PR TITLE
fix(changelog): improve word wrap and line length config/flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,12 @@ pub struct ChangelogCommand {
     /// Follow only the first parent of merge commits. Commits from the merged branche(s) will be discarded.
     #[clap(long)]
     pub first_parent: bool,
+    /// Max line length before wrapping
+    #[clap(long)]
+    pub line_length: Option<usize>,
+    /// Do not wrap lines
+    #[clap(long)]
+    pub no_wrap: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/src/conventional/changelog.rs
+++ b/src/conventional/changelog.rs
@@ -1,10 +1,12 @@
+mod handlebars;
+
 use std::{
     fs::File,
     io::{self, BufReader, Read},
     path::Path,
 };
 
-use handlebars::{no_escape, Handlebars};
+use ::handlebars::Handlebars;
 use serde::Serialize;
 use time::Date;
 use walkdir::WalkDir;
@@ -29,7 +31,7 @@ pub(crate) struct Reference<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) struct Note {
     pub(crate) scope: Option<String>,
-    pub(crate) text: Vec<String>,
+    pub(crate) text: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -129,9 +131,7 @@ pub(crate) struct ChangelogWriter<W: io::Write> {
 
 impl<W: io::Write> ChangelogWriter<W> {
     pub(crate) fn new(template: Option<&Path>, config: &Config, writer: W) -> Result<Self, Error> {
-        let mut handlebars = Handlebars::new();
-        handlebars.set_strict_mode(true);
-        handlebars.register_escape_fn(no_escape);
+        let mut handlebars = self::handlebars::new(config.line_length, config.wrap_disabled);
 
         fn replace_url_formats(tpl_str: &str, config: &Config) -> String {
             tpl_str

--- a/src/conventional/changelog/commit.hbs
+++ b/src/conventional/changelog/commit.hbs
@@ -1,13 +1,11 @@
-*{{#if scope}} **{{scope}}:**
-{{~/if}} {{subject}}
-{{#if hash}}  {{#if @root.linkReferences}}([{{shortHash}}]({{commitUrlFormat}})){{else}}({{shortHash}})
-{{~/if}}
-{{~/if}}
-{{#if references}},
-  closes
+{{#word-wrap}}
+*{{#if scope}} **{{scope}}:**{{/if}} {{subject}}
+{{~#if hash}} {{#if @root.linkReferences}}([{{shortHash}}]({{commitUrlFormat}})){{else}}({{shortHash}}){{/if}}{{/if}}
+{{~#if references}}, closes
   {{~#each references}} {{#if @root.linkReferences~}}
     [{{this.prefix}}{{this.issue}}]({{issueUrlFormat}})
   {{~else}}{{this.prefix}}{{this.issue}}
   {{~/if}}{{/each}}
 {{~/if}}
 
+{{/word-wrap}}

--- a/src/conventional/changelog/handlebars.rs
+++ b/src/conventional/changelog/handlebars.rs
@@ -1,0 +1,114 @@
+use std::borrow::Cow;
+
+use handlebars::{
+    no_escape, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
+    Renderable, StringOutput,
+};
+
+fn word_wrap_acc<'a>(
+    mut acc: Vec<Cow<'a, str>>,
+    word: &'a str,
+    line_length: usize,
+) -> Vec<Cow<'a, str>> {
+    let length = acc.len();
+    if length != 0 {
+        let last_line = acc.last().unwrap();
+        if last_line.len() + word.len() < line_length {
+            acc[length - 1] = format!("{} {}", last_line, word).into();
+        } else {
+            acc.push(word.into());
+        }
+    } else {
+        acc.push(word.into());
+    }
+    acc
+}
+
+fn word_wrap(s: &str, line_length: usize) -> String {
+    s.split(' ')
+        .fold(Vec::new(), |acc, word| {
+            word_wrap_acc(acc, word, line_length - 2)
+        })
+        .join("\n")
+}
+
+/// Helper for handlebars, does not wrap existing lines
+///
+/// ```hbs
+/// {{#word-wrap}}
+/// The quick brown fox jumps over the lazy dog
+/// {{/word-wrap}}
+/// ```
+struct WordWrapBlock {
+    max: usize,
+    disabled: bool,
+}
+
+impl HelperDef for WordWrapBlock {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let mut unwrapped = StringOutput::new();
+        h.template()
+            .map(|t| t.render(r, ctx, rc, &mut unwrapped))
+            .unwrap_or(Ok(()))?;
+        let unwrapped = unwrapped.into_string()?;
+        let unwrapped = unwrapped.as_str();
+
+        if self.disabled {
+            out.write(unwrapped)?;
+        } else {
+            let wrapped = word_wrap(unwrapped, self.max);
+            out.write(&wrapped)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn new(max: usize, disabled: bool) -> Handlebars<'static> {
+    let mut handlebars = Handlebars::new();
+    handlebars.set_strict_mode(true);
+    handlebars.register_escape_fn(no_escape);
+    handlebars.register_helper("word-wrap", Box::new(WordWrapBlock { max, disabled }));
+    handlebars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_word_wrap_block() {
+        let template =
+            r#"{{#word-wrap max=8}}The quick brown fox jumps over the lazy dog{{/word-wrap}}"#;
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper(
+            "word-wrap",
+            Box::new(WordWrapBlock {
+                max: 8,
+                disabled: false,
+            }),
+        );
+        let result = handlebars.render_template(template, &()).unwrap();
+        assert_eq!(
+            result,
+            "The\nquick\nbrown\nfox\njumps\nover\nthe\nlazy\ndog"
+        )
+    }
+
+    #[test]
+    fn test_word_wrap() {
+        let s = "The quick brown fox jumps over the lazy dog";
+        assert_eq!(word_wrap(s, 80), s);
+        assert_eq!(
+            word_wrap(s, 8),
+            "The\nquick\nbrown\nfox\njumps\nover\nthe\nlazy\ndog"
+        );
+    }
+}

--- a/src/conventional/changelog/template.hbs
+++ b/src/conventional/changelog/template.hbs
@@ -3,8 +3,7 @@
 
 ### ⚠ {{title}}
 
-{{#each notes}}* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{#each text}}{{this}}
-{{~/each}}
+{{#each notes}}* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{this.text}}
 {{/each}}
 {{/each}}
 {{/if}}

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -72,6 +72,9 @@ pub(crate) struct Config {
     /// default number of characters in a single line of the CHANGELOG.
     #[serde(default = "default_line_length")]
     pub(crate) line_length: usize,
+    /// default number of characters in a single line of the CHANGELOG.
+    #[serde(default)]
+    pub(crate) wrap_disabled: bool,
     /// Add link to compare 2 versions.
     #[serde(default = "default_true")]
     pub(crate) link_compare: bool,
@@ -113,6 +116,7 @@ impl Default for Config {
             link_references: true,
             merges: false,
             first_parent: false,
+            wrap_disabled: false,
         }
     }
 }
@@ -421,6 +425,7 @@ mod tests {
                 link_references: true,
                 merges: false,
                 first_parent: false,
+                wrap_disabled: false,
             }
         )
     }


### PR DESCRIPTION
Currently lines are wrapped based on the description only but not on the scope. Now the word-wrap is part of the template and takes the full line into account.

```hbs
{{#word-wrap}}
..
{{/word-wrap}}
```

This also add control for word wrap and line length as flags.

`--no-wrap` to disable wrapping.
`--line-length <LINE_LENGTH>` to set the line length.

Refs: #84