### PR TITLE
fix: improve error handling in case the git repo could not be opened

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,18 @@ use git::GitHelper;
 
 pub(crate) use crate::{cmd::Command, error::Error};
 
-fn main() -> Result<(), Error> {
+fn main() -> anyhow::Result<()> {
     let opt: cli::Opt = cli::Opt::parse();
     if let Some(path) = opt.path {
         std::env::set_current_dir(path)?;
     }
-    let git = GitHelper::new("v")?;
+    let git = GitHelper::new("v").map_err(|e|
+        if e.message().contains("config value 'safe.directory' was not found") {
+            anyhow::Error::new(e).context("Could not open the git repository.\nIf run from docker set the right user id and group id.\nE.g. `docker run -u \"$(id -u):$(id -g)\" -v \"$PWD:/tmp\" --workdir /tmp --rm convco/convco`")
+        } else {
+            anyhow::Error::new(e)
+        }
+        )?;
     let config = make_cl_config(&git, opt.config.unwrap_or_else(|| ".versionrc".into()));
     let res = match opt.cmd {
         cli::Command::Check(cmd) => cmd.exec(config),


### PR DESCRIPTION
If the git repo can't be opened because of the `safe.directory` config a hint will be printed:

> Could not open the git repository.
> If run from docker set the right user id and group id.
> E.g. `docker run -u \"$(id -u):$(id -g)\" -v \"$PWD:/tmp\" --workdir /tmp --rm convco/convco`

Refs: #86