### PR TITLE
small fixes after release v0.3.13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
           # A PR should not contain too many commits
           fetch-depth: 10
       - name: Validate commit messages
+        shell: 'script -q -e -c "bash {0}"'
         run: |
           git show-ref
           curl -sSfL https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip | zcat > convco

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,8 +66,10 @@ pub struct VersionCommand {
 #[derive(Debug, Parser)]
 pub struct CheckCommand {
     /// Start of the revwalk, can also be a commit range. Can be in the form `<commit>..<commit>`.
-    #[clap(default_value = "HEAD")]
-    pub rev: String,
+    /// If not provided and a tty it will check from HEAD.
+    /// If not provided and not a tty it will check a single commit message from stdin.
+    #[clap()]
+    pub rev: Option<String>,
     /// Limit the number of commits to check.
     #[clap(short, long = "max-count")]
     pub number: Option<usize>,

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -43,7 +43,6 @@ struct ChangeLogTransformer<'a> {
     context_builder: ContextBuilder<'a>,
     commit_parser: CommitParser,
     paths: &'a [PathBuf],
-    changelog_command: &'a ChangelogCommand,
 }
 
 fn date_from_time(time: &Time) -> Date {
@@ -59,7 +58,6 @@ impl<'a> ChangeLogTransformer<'a> {
         git: &'a GitHelper,
         paths: &'a [PathBuf],
         unreleased: String,
-        changelog_command: &'a ChangelogCommand,
     ) -> Result<Self, Error> {
         let group_types = config
             .types
@@ -94,7 +92,6 @@ impl<'a> ChangeLogTransformer<'a> {
             commit_parser,
             paths,
             unreleased,
-            changelog_command,
         })
     }
 
@@ -202,11 +199,10 @@ impl<'a> ChangeLogTransformer<'a> {
         }
 
         let version = if from_rev.0 == "HEAD" {
-            format!(
-                "{}{}",
-                self.changelog_command.prefix, self.changelog_command.unreleased
-            )
-            .into()
+            match &self.unreleased.version {
+                Some(v) => format!("v{}", v.0).into(),
+                None => self.unreleased.str.as_str().into(),
+            }
         } else {
             from_rev.0.into()
         };
@@ -306,7 +302,6 @@ impl ChangelogCommand {
             &helper,
             &self.paths,
             self.unreleased.clone(),
-            self,
         )?;
         match helper
             .find_last_version(rev)

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -64,7 +64,7 @@ impl Command for CheckCommand {
 
         let Config { merges, .. } = config;
 
-        if self.rev == "HEAD" && !stdin().is_terminal() {
+        if self.rev.is_some() && !stdin().is_terminal() {
             let mut stdin = stdin().lock();
             let mut commit_msg = String::new();
             stdin.read_to_string(&mut commit_msg)?;
@@ -77,10 +77,15 @@ impl Command for CheckCommand {
         if config.first_parent {
             revwalk.simplify_first_parent()?;
         }
-        if self.rev.contains("..") {
-            revwalk.push_range(self.rev.as_str())?;
+        let rev = match self.rev.as_ref() {
+            Some(rev) if !rev.is_empty() => rev.as_str(),
+            _ => "HEAD",
+        };
+
+        if rev.contains("..") {
+            revwalk.push_range(rev)?;
         } else {
-            revwalk.push_ref(self.rev.as_str())?;
+            revwalk.push_ref(rev)?;
         }
 
         for commit in revwalk

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -64,7 +64,7 @@ impl Command for CheckCommand {
 
         let Config { merges, .. } = config;
 
-        if !stdin().is_terminal() {
+        if self.rev == "HEAD" && !stdin().is_terminal() {
             let mut stdin = stdin().lock();
             let mut commit_msg = String::new();
             stdin.read_to_string(&mut commit_msg)?;


### PR DESCRIPTION
When `--unreleased` is not a version it will not be prefixed.

Closes: #101