### PR TITLE
feat(version): allows bumping a prerelease version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ walkdir = "2.3.2"
 [build-dependencies]
 clap = { version = "4.0.26", features = ["derive"] }
 clap_complete = "4.0.5"
+semver = "1.0.14"
 
 [package.metadata.deb]
 depends = ""

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use clap::Parser;
+use semver::Prerelease;
 
 #[derive(Debug, Parser)]
 #[clap(name = "convco", about = "Conventional commit tools", version)]
@@ -58,6 +59,9 @@ pub struct VersionCommand {
     /// Bump to a patch release version, regardless of the conventional commits
     #[clap(long)]
     pub patch: bool,
+    /// Suffix with a prerelease version. Requires --bump.
+    #[clap(long, requires = "bump", default_value_t = Prerelease::new("").unwrap())]
+    pub prerelease: Prerelease,
     /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
     #[clap(short = 'P', long)]
     pub paths: Vec<PathBuf>,

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -49,6 +49,21 @@ impl SemVer {
         self.0.pre = Prerelease::EMPTY
     }
 
+    pub fn increment_prerelease(&mut self, prerelease: &Prerelease) {
+        if self.0.pre.is_empty() {
+            self.0.pre = Prerelease::new(format!("{prerelease}.1").as_str()).unwrap();
+        } else {
+            let next = self
+                .0
+                .pre
+                .split_once('.')
+                .and_then(|(_, number)| number.parse::<u64>().ok())
+                .unwrap_or_default()
+                + 1;
+            self.0.pre = Prerelease::new(format!("{prerelease}.{next}").as_str()).unwrap();
+        }
+    }
+
     pub fn build_clear(&mut self) {
         self.0.build = BuildMetadata::EMPTY
     }


### PR DESCRIPTION
When prerelease is given as a parameter with the value 'beta', the version would look like: `x.y.z-beta.1`, if this tag is present, the next bump would be `x.y.z-beta.2`.

Fixes: #90