### PR TITLE
Fix/check single rev

### DIFF
--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -88,7 +88,8 @@ impl Command for CheckCommand {
         if rev.contains("..") {
             revwalk.push_range(rev)?;
         } else {
-            revwalk.push_ref(rev)?;
+            let oid = repo.revparse_single(rev)?.id();
+            revwalk.push(oid)?;
         }
 
         for commit in revwalk


### PR DESCRIPTION
Single revisions where pushed to the revwalk with `push_ref`. 
But this only pushes refspecs and not all parseble single revisions.