### PR TITLE
feat: make `zlib-ng-compat` a default feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -289,9 +289,9 @@ checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
  "bitflags",
  "libc",
@@ -415,9 +415,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.15.1+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
 dependencies = [
  "cc",
  "libc",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",
@@ -512,11 +512,10 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ include = [
     "README.md",
     "LICENSE"
 ]
+rust-version = "1.60" # for `--features`
 
 [dependencies]
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 clap = { version = "4.1.2", features = ["derive"] }
 ctrlc = "3.2.4"
 dialoguer = "0.10.3"
-git2 = { version = "0.16.1", default-features = false, features = [ "zlib-ng-compat" ] }
+git2 = { version = "0.17.1", default-features = false }
 handlebars = "4.3.6"
 regex = "1.7.1"
 semver = "1.0.16"
@@ -37,6 +38,10 @@ walkdir = "2.3.2"
 clap = { version = "4.1.2", features = ["derive"] }
 clap_complete = "4.1.1"
 semver = "1.0.16"
+
+[features]
+default = ["zlib-ng-compat"]
+zlib-ng-compat = ["git2/zlib-ng-compat"]
 
 [package.metadata.deb]
 depends = ""

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ It provides the following commands:
 
 `cargo install convco`
 
-This build depends on `git2` with the `zlib-ng-compat` feature. It requires `cmake`.
+## Building from source
+
+Rust 1.60 or newer is required.
+
+Building with `cargo` depends on `git2` and `cmake` due to linking with `zlib-ng`.
+You can optionally disable this by changing the defaults for a build:
+```console
+$ cargo build --no-default-features
+```
 
 ## Configuration
 


### PR DESCRIPTION
This way it can be turned off via `cargo build --no-default-flags` which is required to link against a shared `libgit2`.

This PR also bumps `git2-rs` to link against the `1.6`  branch of `libgit2`