### PR TITLE
feat: strip prefix regex

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -71,6 +71,7 @@ impl<'a> ChangeLogTransformer<'a> {
             });
         let commit_parser = CommitParser::builder()
             .scope_regex(config.scope_regex.clone())
+            .strip_regex(config.strip_regex.clone())
             .references_regex(format!("({})([0-9]+)", config.issue_prefixes.join("|")))
             .build();
 

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -54,6 +54,7 @@ impl Command for CheckCommand {
 
         let parser = conventional::CommitParser::builder()
             .scope_regex(config.scope_regex)
+            .strip_regex(config.strip_regex)
             .build();
         let types: Vec<Type> = config
             .types

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -114,7 +114,11 @@ impl VersionCommand {
         Ok((last_version.0, label))
     }
 
-    fn get_version(&self, scope_regex: String) -> Result<(Version, Label), Error> {
+    fn get_version(
+        &self,
+        scope_regex: String,
+        strip_regex: String,
+    ) -> Result<(Version, Label), Error> {
         if let Some(VersionAndTag { tag, mut version }) = self.find_last_version()? {
             let v = if self.major {
                 version.increment_major();
@@ -136,7 +140,10 @@ impl VersionCommand {
                         (version.0, Label::Prerelease)
                     }
                 } else {
-                    let parser = CommitParser::builder().scope_regex(scope_regex).build();
+                    let parser = CommitParser::builder()
+                        .scope_regex(scope_regex)
+                        .strip_regex(strip_regex)
+                        .build();
                     self.find_bump_version(tag.as_str(), version, &parser)?
                 }
             } else {
@@ -157,7 +164,7 @@ impl VersionCommand {
 
 impl Command for VersionCommand {
     fn exec(&self, config: Config) -> anyhow::Result<()> {
-        let (version, label) = self.get_version(config.scope_regex)?;
+        let (version, label) = self.get_version(config.scope_regex, config.strip_regex)?;
         if self.label {
             println!("{label}");
         } else {

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -89,6 +89,9 @@ pub(crate) struct Config {
     /// Follow only the first parent
     #[serde(default)]
     pub first_parent: bool,
+    /// Strip the commit message(s) by the given regex pattern
+    #[serde(default = "default_strip_regex")]
+    pub(crate) strip_regex: String,
 }
 
 const fn default_true() -> bool {
@@ -119,6 +122,7 @@ impl Default for Config {
             merges: false,
             first_parent: false,
             wrap_disabled: false,
+            strip_regex: "".to_string(),
         }
     }
 }
@@ -212,6 +216,10 @@ fn default_issue_prefixes() -> Vec<String> {
 
 fn default_scope_regex() -> String {
     "[[:alnum:]]+(?:[-_/][[:alnum:]]+)*".to_string()
+}
+
+fn default_strip_regex() -> String {
+    "".to_string()
 }
 
 type HostOwnerRepo = (Option<String>, Option<String>, Option<String>);
@@ -428,6 +436,7 @@ mod tests {
                 merges: false,
                 first_parent: false,
                 wrap_disabled: false,
+                strip_regex: "".to_string(),
             }
         )
     }


### PR DESCRIPTION
resolve: #133 

Hi I have implemented a feature to strip a regex pattern from the commit message before parsing the the message. 

Currently this works via config file, however, I would like to have it as flag as well, but didnt manage to get it working as excepted. When defining the flags as clap options they would not be used for some reason. Perhaps the default value from the config would overwrite them. 

As I am not familar with rust, I copied what I saw for other options. So please review careful and let me know if there is any issue.
