### PR TITLE
Fix/151

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.60" # for `--features`
 
 [dependencies]
 anyhow = { version = "1.0.72", features = ["backtrace"] }
-clap = { version = "4.3.19", features = ["derive"] }
+clap = { version = "4.3.19", features = ["derive", "env"] }
 ctrlc = "3.4.0"
 dialoguer = "0.11.0"
 git2 = { version = "0.18.1", default-features = false }
@@ -35,7 +35,7 @@ url = "2.4.0"
 walkdir = "2.3.3"
 
 [build-dependencies]
-clap = { version = "4.3.19", features = ["derive"] }
+clap = { version = "4.3.19", features = ["derive", "env"] }
 clap_complete = "4.3.2"
 semver = "1.0.18"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ pub struct Opt {
     /// Run as if convco was started in <path> instead of the current working directory.
     #[clap(short = 'C', global = true)]
     pub path: Option<PathBuf>,
-    #[clap(short = 'c', long = "config", global = true)]
+    #[clap(short = 'c', long = "config", global = true, env = "CONVCO_CONFIG")]
     pub config: Option<PathBuf>,
     #[clap(subcommand)]
     pub cmd: Command,
@@ -39,7 +39,7 @@ pub struct ConfigCommand {
 #[derive(Debug, Parser)]
 pub struct VersionCommand {
     /// Prefix used in front of the semantic version
-    #[clap(short, long, default_value = "v")]
+    #[clap(short, long, default_value = "v", env = "CONVCO_PREFIX")]
     pub prefix: String,
     /// Revision to show the version for
     #[clap(default_value = "HEAD")]
@@ -63,26 +63,26 @@ pub struct VersionCommand {
     #[clap(long, requires = "bump", default_value_t = Prerelease::new("").unwrap())]
     pub prerelease: Prerelease,
     /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
-    #[clap(short = 'P', long)]
+    #[clap(short = 'P', long, env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
 pub struct CheckCommand {
     /// Start of the revwalk, can also be a commit range. Can be in the form `<commit>..<commit>`.
-    #[clap()]
+    #[clap(env = "CONVCO_REV")]
     pub rev: Option<String>,
     /// Limit the number of commits to check.
-    #[clap(short, long = "max-count")]
+    #[clap(short, long = "max-count", env = "CONVCO_MAX_COUNT")]
     pub number: Option<usize>,
     /// Include conventional merge commits (commits with more than 1 parent) in the changelog.
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_MERGES")]
     pub merges: bool,
     /// Follow only the first parent
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_FIRST_PARENT")]
     pub first_parent: bool,
     /// Ignore commits created by `git revert` commands
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_IGNORE_REVERTS")]
     pub ignore_reverts: bool,
     /// Read a single commit message from stdin
     #[clap(long)]
@@ -96,53 +96,53 @@ pub struct CheckCommand {
 #[derive(Debug, Parser)]
 pub struct ChangelogCommand {
     /// Prefix used in front of the semantic version.
-    #[clap(short, long, default_value = "v")]
+    #[clap(short, long, default_value = "v", env = "CONVCO_PREFIX")]
     pub prefix: String,
-    #[clap(default_value = "HEAD")]
+    #[clap(default_value = "HEAD", env = "CONVCO_REV")]
     pub rev: String,
-    #[clap(short, long)]
+    #[clap(short, long, env = "CONVCO_SKIP_EMPTY")]
     pub skip_empty: bool,
     /// Limits the number of version tags to add in the changelog.
-    #[clap(short, long)]
+    #[clap(short, long, env = "CONVCO_MAX_VERSIONS")]
     pub max_versions: Option<usize>,
     /// Only print this number of minor versions.
-    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true, env = "CONVCO_MAX_MINORS")]
     pub max_minors: u64,
     /// Only show this number of major versions.
-    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true, env = "CONVCO_MAX_MAJORS")]
     pub max_majors: u64,
     /// Only show this number of patch versions.
-    #[clap(long, default_value_t=u64::MAX, hide_default_value=true)]
+    #[clap(long, default_value_t=u64::MAX, hide_default_value=true, env = "CONVCO_MAX_PATCHES")]
     pub max_patches: u64,
     /// Do not generate links. Overrides linkReferences and linkCompare in the config.
-    #[clap(short, long)]
+    #[clap(short, long, env = "CONVCO_NO_LINKS")]
     pub no_links: bool,
     /// Include conventional merge commits (commits with more than 1 parent) in the changelog.
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_MERGES")]
     pub merges: bool,
     /// Print hidden sections
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_INCLUDE_HIDDEN_SECTIONS")]
     pub include_hidden_sections: bool,
     /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
-    #[clap(short = 'P', long)]
+    #[clap(short = 'P', long, env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
     /// Follow only the first parent of merge commits. Commits from the merged branche(s) will be discarded.
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_FIRST_PARENT")]
     pub first_parent: bool,
     /// Max line length before wrapping.
     /// This only makes sense if the template makes use of `{{#word-wrap}}` blocks.
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_LINE_LENGTH")]
     pub line_length: Option<usize>,
     /// Do not wrap lines.
     /// This only makes sense if the template makes use of `{{#word-wrap}}` blocks.
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_NO_WRAP")]
     pub no_wrap: bool,
     /// Change the title for the unreleased commits.
     /// If a semantic version is given, the title will be prefixed.
-    #[clap(short, long, default_value = "Unreleased")]
+    #[clap(short, long, default_value = "Unreleased", env = "CONVCO_UNRELEASED")]
     pub unreleased: String,
     /// Path to write the changelog to.
-    #[clap(short, long, default_value = "-")]
+    #[clap(short, long, default_value = "-", env = "CONVCO_OUTPUT")]
     pub output: PathBuf,
 }
 
@@ -221,7 +221,7 @@ pub struct CommitCommand {
     #[clap(long)]
     pub breaking: bool,
     /// Interactive mode
-    #[clap(long, short)]
+    #[clap(long, short, env = "CONVCO_INTERACTIVE")]
     pub interactive: bool,
     /// Extra arguments passed to the git commit command
     #[clap(last = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -220,9 +220,18 @@ pub struct CommitCommand {
     /// Introduces a breaking change
     #[clap(long)]
     pub breaking: bool,
-    /// Interactive mode
+    /// Interactive mode. Start the wizard if no type and description is given.
     #[clap(long, short, env = "CONVCO_INTERACTIVE")]
     pub interactive: bool,
+    /// Runs `git add -N <PATH>`.
+    /// An entry for the path is placed in the index with no content.
+    /// This is useful in combination with --patch.
+    #[clap(short = 'N', long, env = "CONVCO_INTENT_TO_ADD")]
+    pub intent_to_add: Vec<PathBuf>,
+    /// Runs `git add -p`.
+    /// Interactively choose hunks of patch between the index and the work tree.
+    #[clap(short, long, env = "CONVCO_PATCH")]
+    pub patch: bool,
     /// Extra arguments passed to the git commit command
     #[clap(last = true)]
     pub extra_args: Vec<String>,


### PR DESCRIPTION
Add flags for intent to add and patch for convco commit.
The previous behavior to default enable it can be restored by setting the env variables `CONVCO_INTENT_TO_ADD=.` and `CONVCO_PATCH=true`