### PR TITLE
feat(commit): save message to a file to recover or use as a git editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ convco check $remote_sha..$local_sha
 
 Helps to make conventional commits.
 A scope, description, body, breaking change and issues will be prompted.
+Convco will recover the previous message in case git failed to create the commit.
 
 ```sh
-# commit a new feature and then run git commit with the interactive patch switch
-convco commit --feat -- --patch
+convco commit --feat
 ```
+
+`convco commit` can also be used as [git editor](https://git-scm.com/docs/git-var#Documentation/git-var.txt-GITEDITOR).
+In this case `convco commit` will not invoke `git commit`, but `git` will invoke `convco commit`
 
 ### Version
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,6 +238,10 @@ pub struct CommitCommand {
     /// Interactively choose hunks of patch between the index and the work tree.
     #[clap(short, long, env = "CONVCO_PATCH")]
     pub patch: bool,
+    /// Path to store the commit message to recover from in case of an error
+    /// If the path is `$GIT_DIR/COMMIT_EDITMSG` convco will not call `git commit`
+    #[clap(hide = true)]
+    pub commit_msg_path: Option<PathBuf>,
     /// Extra arguments passed to the git commit command
     #[clap(last = true)]
     pub extra_args: Vec<String>,

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -332,10 +332,10 @@ impl ChangelogCommand {
                 let is_head = from_rev.0 == "HEAD";
                 let iter = Some(from_rev).into_iter();
                 let iter = if is_head {
-                    iter.chain(
-                        Some(Rev(last_version.tag.as_str(), Some(&last_version.version)))
-                            .into_iter(),
-                    )
+                    iter.chain(Some(Rev(
+                        last_version.tag.as_str(),
+                        Some(&last_version.version),
+                    )))
                 } else {
                     iter.chain(None)
                 };

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -117,7 +117,7 @@ impl Command for CheckCommand {
             let msg = std::str::from_utf8(commit.message_bytes()).expect("valid utf-8 message");
             let short_id = commit.as_object().short_id().unwrap();
             let short_id = short_id.as_str().expect("short id");
-            fail += u32::from(!print_check(&msg, &short_id, &parser, &types));
+            fail += u32::from(!print_check(msg, short_id, &parser, &types));
         }
         if fail == 0 {
             match total {

--- a/src/conventional/commits.rs
+++ b/src/conventional/commits.rs
@@ -269,22 +269,22 @@ impl CommitParserBuilder {
 
     pub fn build(&self) -> CommitParser {
         let regex_first_line = Regex::new(
-            r#"(?xms)
+            r"(?xms)
         ^
         (?P<type>[a-zA-Z]+)
         (?:\((?P<scope>[^()\r\n]+)\))?
         (?P<breaking>!)?
         :\x20(?P<desc>[^\r\n]+)
-        $"#,
+        $",
         )
         .expect("valid scope regex");
         let regex_footer = Regex::new(
-            r#"(?xm)
+            r"(?xm)
                     ^
                     (?:(?P<key>(?:BREAKING\x20CHANGE|[a-zA-Z]+(?:-[a-zA-Z]+)*)):\x20|
                     (?P<ref>[a-zA-Z]+(?:-[a-zA-Z]+)*)\x20\#)
                     (?P<value>.+)
-                    $"#,
+                    $",
         )
         .unwrap();
         let regex_scope =

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, process::ExitStatus};
 
 use handlebars::{RenderError, TemplateError};
 use thiserror::Error;
@@ -31,4 +31,6 @@ pub(crate) enum Error {
     Type { wrong_type: String },
     #[error("canceled by user")]
     CancelledByUser,
+    #[error("git commit failed: {0}")]
+    GitCommitFailed(ExitStatus),
 }


### PR DESCRIPTION
This save the convco commit message to a file `.git/convco_msg`. In case a pre-commit hook failed, the next run of `convco commit` would recover from this file. `convco commit` can now also be used as a git editor. In this case git will call convco commit and not the other way around.

Refs: #157