### PR TITLE
feat!: allow multiple values for the paths argument

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,7 +66,7 @@ pub struct VersionCommand {
     #[clap(long, requires = "bump", default_value_t = Prerelease::new("").unwrap())]
     pub prerelease: Prerelease,
     /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
-    #[clap(short = 'P', long, env = "CONVCO_PATHS")]
+    #[clap(short = 'P', long, num_args=0.., env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
     /// Print the commit-sha of the version instead of the semantic version
     #[clap(long)]
@@ -130,7 +130,7 @@ pub struct ChangelogCommand {
     #[clap(long, env = "CONVCO_INCLUDE_HIDDEN_SECTIONS")]
     pub include_hidden_sections: bool,
     /// Only commits that update those <paths> will be taken into account. It is useful to support monorepos.
-    #[clap(short = 'P', long, env = "CONVCO_PATHS")]
+    #[clap(short = 'P', long, num_args=0.., env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
     /// Follow only the first parent of merge commits. Commits from the merged branche(s) will be discarded.
     #[clap(long, env = "CONVCO_FIRST_PARENT")]


### PR DESCRIPTION
This makes it possible to use shell globbing.

BREAKING CHANGE: as multiple values are parsed the position should be last or the rev argument should be set after --

Refs: #160