### PR TITLE
Configurable version increments per Type

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -196,7 +196,7 @@ impl<'a> ChangeLogTransformer<'a> {
                     short_hash,
                     references,
                 };
-                if let Some(section) = self.group_types.get(conv_commit.r#type.as_ref()) {
+                if let Some(section) = self.group_types.get(conv_commit.r#type.as_str()) {
                     commits.entry(section).or_default().push(commit_context)
                 }
             }

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -6,7 +6,7 @@ use git2::Repository;
 use crate::{
     cli::CheckCommand,
     cmd::Command,
-    conventional::{self, Type},
+    conventional,
     git::{filter_merge_commits, filter_revert_commits},
     strip::Strip,
     Error,
@@ -23,7 +23,7 @@ fn print_fail(msg: &str, short_id: &str, e: Error) -> bool {
     false
 }
 
-fn print_wrong_type(msg: &str, short_id: &str, commit_type: Type) -> bool {
+fn print_wrong_type(msg: &str, short_id: &str, commit_type: String) -> bool {
     print_fail(
         msg,
         short_id,
@@ -37,7 +37,7 @@ fn print_check(
     msg: &str,
     short_id: &str,
     parser: &conventional::CommitParser,
-    types: &[Type],
+    types: &[String],
 ) -> bool {
     let msg_parsed = parser.parse(msg);
 
@@ -66,11 +66,11 @@ impl Command for CheckCommand {
             .scope_regex(config.scope_regex)
             .strip_regex(config.strip_regex)
             .build();
-        let types: Vec<Type> = config
+        let types: Vec<String> = config
             .types
             .iter()
             .map(|ty| ty.r#type.as_str())
-            .map(Type::from)
+            .map(String::from)
             .collect();
 
         let Config { merges, .. } = config;

--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -113,11 +113,7 @@ fn edit_message(msg: &str) -> Result<String, Error> {
         .strip())
 }
 
-fn edit_loop(
-    msg: &str,
-    parser: &CommitParser,
-    types: &[crate::conventional::Type],
-) -> Result<String, Error> {
+fn edit_loop(msg: &str, parser: &CommitParser, types: &[String]) -> Result<String, Error> {
     let mut edit_msg = msg.to_owned();
     loop {
         edit_msg = edit_message(&edit_msg)?;
@@ -374,11 +370,11 @@ impl Command for CommitCommand {
     }
 }
 
-fn config_types_to_conventional(types: &[Type]) -> Vec<crate::conventional::Type> {
+fn config_types_to_conventional(types: &[Type]) -> Vec<String> {
     types
         .iter()
         .map(|ty| ty.r#type.as_str())
-        .map(crate::conventional::Type::from)
+        .map(String::from)
         .collect()
 }
 

--- a/src/conventional.rs
+++ b/src/conventional.rs
@@ -23,5 +23,5 @@ pub(crate) mod changelog;
 mod commits;
 pub(crate) mod config;
 
-pub(crate) use commits::{CommitParser, Footer, ParseError, Type};
+pub(crate) use commits::{CommitParser, Footer, ParseError};
 pub(crate) use config::Config;

--- a/src/conventional/commits.rs
+++ b/src/conventional/commits.rs
@@ -5,66 +5,6 @@ use serde::Serialize;
 use thiserror::Error;
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Type {
-    Build,
-    Chore,
-    Ci,
-    Docs,
-    Feat,
-    Fix,
-    Perf,
-    Refactor,
-    Revert,
-    Style,
-    Test,
-    Custom(String),
-}
-
-impl AsRef<str> for Type {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Build => "build",
-            Self::Chore => "chore",
-            Self::Ci => "ci",
-            Self::Docs => "docs",
-            Self::Feat => "feat",
-            Self::Fix => "fix",
-            Self::Perf => "perf",
-            Self::Refactor => "refactor",
-            Self::Revert => "revert",
-            Self::Style => "style",
-            Self::Test => "test",
-            Self::Custom(c) => c.as_str(),
-        }
-    }
-}
-
-impl From<&str> for Type {
-    fn from(s: &str) -> Type {
-        match s.to_ascii_lowercase().as_str() {
-            "build" => Self::Build,
-            "chore" => Self::Chore,
-            "ci" => Self::Ci,
-            "docs" => Self::Docs,
-            "feat" => Self::Feat,
-            "fix" => Self::Fix,
-            "perf" => Self::Perf,
-            "refactor" => Self::Refactor,
-            "revert" => Self::Revert,
-            "style" => Self::Style,
-            "test" => Self::Test,
-            custom => Self::Custom(custom.to_owned()),
-        }
-    }
-}
-
-impl fmt::Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_ref())
-    }
-}
-
-#[derive(Debug, PartialEq)]
 pub(crate) struct Footer {
     pub(crate) key: String,
     pub(crate) value: String,
@@ -79,7 +19,7 @@ pub(crate) struct Reference {
 
 #[derive(Debug, PartialEq)]
 pub struct Commit {
-    pub(crate) r#type: Type,
+    pub(crate) r#type: String,
     pub(crate) scope: Option<String>,
     pub(crate) breaking: bool,
     pub(crate) description: String,
@@ -136,7 +76,7 @@ impl CommitParser {
         let mut lines = s.lines();
         if let Some(first) = lines.next() {
             if let Some(capts) = self.regex_first_line.captures(first) {
-                let r#type: Option<Type> = capts.name("type").map(|t| t.as_str().into());
+                let r#type = capts.name("type").map(|t| t.as_str().to_owned());
                 let scope = capts.name("scope").map(|s| s.as_str().to_owned());
                 if let Some(ref scope) = scope {
                     if !self.regex_scope.is_match(scope.as_str()) {
@@ -318,7 +258,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Docs,
+                r#type: "docs".into(),
                 scope: None,
                 breaking: false,
                 description: "correct spelling of CHANGELOG".into(),
@@ -337,7 +277,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Feat,
+                r#type: "feat".into(),
                 scope: Some("lang".into()),
                 breaking: false,
                 description: "add polish language".into(),
@@ -356,7 +296,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Feat,
+                r#type: "feat".into(),
                 scope: Some("bar2/a_b-C4".into()),
                 breaking: false,
                 description: "add a foo to new bar".into(),
@@ -385,7 +325,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Refactor,
+                r#type: "refactor".into(),
                 scope: None,
                 breaking: true,
                 description: "drop support for Node 6".into(),
@@ -406,7 +346,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Feat,
+                r#type: "feat".into(),
                 scope: None,
                 breaking: false,
                 description: "allow provided config object to extend other configs".into(),
@@ -446,7 +386,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Fix,
+                r#type: "fix".into(),
                 scope: None,
                 breaking: false,
                 description: "correct minor typos in code".into(),
@@ -480,7 +420,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Revert,
+                r#type: "revert".into(),
                 scope: None,
                 breaking: false,
                 description: "let us never again speak of the noodle incident #1".into(),
@@ -522,7 +462,7 @@ mod tests {
         assert_eq!(
             commit,
             Commit {
-                r#type: Type::Docs,
+                r#type: "docs".into(),
                 scope: None,
                 breaking: false,
                 description: "correct spelling of CHANGELOG".into(),

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -9,8 +9,17 @@ use url::Url;
 use crate::{error::Error, git::GitHelper};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) enum Increment {
+    Major,
+    Minor,
+    Patch,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Type {
     pub(crate) r#type: String,
+    pub(crate) increment: Increment,
     #[serde(default)]
     pub(crate) section: String,
     #[serde(default)]
@@ -135,51 +144,61 @@ fn default_types() -> Vec<Type> {
     vec![
         Type {
             r#type: "feat".into(),
+            increment: Increment::Minor,
             section: "Features".into(),
             hidden: false,
         },
         Type {
             r#type: "fix".into(),
+            increment: Increment::Patch,
             section: "Fixes".into(),
             hidden: false,
         },
         Type {
             r#type: "build".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "chore".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "ci".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "docs".into(),
+            increment: Increment::None,
             section: "Documentation".into(),
             hidden: true,
         },
         Type {
             r#type: "style".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "refactor".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "perf".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
         Type {
             r#type: "test".into(),
+            increment: Increment::None,
             section: "Other".into(),
             hidden: true,
         },
@@ -356,61 +375,73 @@ mod tests {
                 types: vec![
                     Type {
                         r#type: "chore".into(),
+                        increment: Increment::Patch,
                         section: "Others".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "revert".into(),
+                        increment: Increment::Patch,
                         section: "Reverts".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "feat".into(),
+                        increment: Increment::Patch,
                         section: "Features".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "fix".into(),
+                        increment: Increment::Patch,
                         section: "Bug Fixes".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "improvement".into(),
+                        increment: Increment::Patch,
                         section: "Feature Improvements".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "docs".into(),
+                        increment: Increment::Patch,
                         section: "Docs".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "style".into(),
+                        increment: Increment::Patch,
                         section: "Styling".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "refactor".into(),
+                        increment: Increment::Patch,
                         section: "Code Refactoring".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "perf".into(),
+                        increment: Increment::Patch,
                         section: "Performance Improvements".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "test".into(),
+                        increment: Increment::Patch,
                         section: "Tests".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "build".into(),
+                        increment: Increment::Patch,
                         section: "Build System".into(),
                         hidden: false
                     },
                     Type {
                         r#type: "ci".into(),
+                        increment: Increment::Patch,
                         section: "CI".into(),
                         hidden: false
                     }


### PR DESCRIPTION
I expect that this PR will be declined as it takes a slightly different view of the ConventionalCommit spec, and actively deviates from the ConventionalChangelog spec, however I would appreciate feedback if possible.

I like convco very much.  However, to be of real value to me I need to be able increment either the major, minor or patch via custom types, not constrained to `feat` and `fix`.  This is allowed by the spec, but not mandated.  This PR removes `conventional::Type` preferring instead for every type to be a `String`.  It then adds a new `Increment` config Type field which allows the specification of which value to increment when that type is encountered in the git history.