### PR TITLE
fix: improve performance for mono repos using the --paths option

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -154,10 +154,12 @@ impl<'a> ChangeLogTransformer<'a> {
             merges,
             ..
         } = self.config;
+        let mut diff_options = crate::git::diff_options_from_paths(self.paths);
+
         for commit in revwalk
             .flatten()
             .flat_map(|oid| self.git.find_commit(oid).ok())
-            .filter(|commit| self.git.commit_updates_any_path(commit, self.paths))
+            .filter(|commit| self.git.commit_updates_any_path(commit, &mut diff_options))
             .filter(|commit| filter_merge_commits(commit, *merges))
         {
             if let Some(Ok(conv_commit)) = commit.message().map(|msg| self.commit_parser.parse(msg))

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -68,10 +68,11 @@ impl VersionCommand {
         let git = GitHelper::new(prefix)?;
         let mut revwalk = git.revwalk()?;
         revwalk.push_range(format!("{}..{}", last_v_tag, self.rev).as_str())?;
+        let mut diff_options = crate::git::diff_options_from_paths(&self.paths);
         let i = revwalk
             .flatten()
             .filter_map(|oid| git.find_commit(oid).ok())
-            .filter(|commit| git.commit_updates_any_path(commit, &self.paths))
+            .filter(|commit| git.commit_updates_any_path(commit, &mut diff_options))
             .filter_map(|commit| {
                 let commit_sha = commit.id().to_string();
 


### PR DESCRIPTION
Delegates the path selection to diff options.
Other improvement to do for `convco version` is to take 1 diff between the previous version and the head instead of 1 diff per commit.

Refs: #194