### PR TITLE
ci: add release-cargo workflow

### DIFF
--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -1,0 +1,18 @@
+name: "release-cargo"
+on:
+  workflow_dispatch:
+jobs:
+  release-cargo:
+    environment: release
+    name: Release Cargo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Install stable toolchain and check style
+        run: |
+          rustup toolchain install --profile minimal stable
+          cargo install --path .
+          cargo install cargo-release
+          cargo release "$(convco version --bump)" --execute


### PR DESCRIPTION
This adds a manual workflow to run cargo-release.
A changelog will be created, the crate will be published and a tag will be created.
The release workflow will trigger as a new tag is created.

Refs: #143