### PR TITLE
keep newline in multiline footers and fix double BREAKING CHANGE BREAKING-CHANGE headers in changelog

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -13,7 +13,7 @@ use crate::{
             Note, NoteGroup, Reference,
         },
         config::Config,
-        CommitParser, Footer,
+        CommitParser, Footer, FooterKey,
     },
     git::{filter_merge_commits, GitHelper, VersionAndTag},
     semver::SemVer,
@@ -102,10 +102,10 @@ impl<'a> ChangeLogTransformer<'a> {
     fn make_notes(&self, footers: &'a [Footer], scope: Option<String>) -> Vec<(String, Note)> {
         footers
             .iter()
-            .filter(|footer| footer.key.starts_with("BREAKING"))
+            .filter(|footer| matches!(footer.key, FooterKey::BreakingChange))
             .map(|footer| {
                 (
-                    footer.key.clone(),
+                    footer.key.to_string(),
                     Note {
                         scope: scope.clone(),
                         text: footer.value.clone(),

--- a/src/conventional.rs
+++ b/src/conventional.rs
@@ -23,5 +23,5 @@ pub(crate) mod changelog;
 mod commits;
 pub(crate) mod config;
 
-pub(crate) use commits::{CommitParser, Footer, ParseError};
+pub(crate) use commits::{CommitParser, Footer, FooterKey, ParseError};
 pub(crate) use config::Config;

--- a/src/conventional/commits.rs
+++ b/src/conventional/commits.rs
@@ -126,8 +126,8 @@ impl CommitParser {
                                 body.push_str(line);
                                 body.push('\n');
                             } else if let Some(footer) = footers.last_mut() {
-                                footer.value.push_str(line);
                                 footer.value.push('\n');
+                                footer.value.push_str(line);
                             }
                             for captures in self.regex_references.captures_iter(line) {
                                 let prefix = &captures[1];
@@ -370,6 +370,19 @@ mod tests {
                          BREAKING-CHANGE: `extends` key in config file is now used for extending other config files";
         let commit: Commit = parser().parse(msg).expect("valid");
         assert!(commit.is_breaking());
+    }
+
+    #[test]
+    fn test_with_breaking_footer_newline() {
+        let msg = "feat: allow provided config object to extend other configs\n\
+                         \n\
+                         BREAKING-CHANGE: `extends` key in config\nfile is now used for extending other config files";
+        let commit: Commit = parser().parse(msg).expect("valid");
+        assert!(commit.is_breaking());
+        assert_eq!(
+            commit.footers.first().unwrap().value,
+            "`extends` key in config\nfile is now used for extending other config files"
+        )
     }
 
     #[test]


### PR DESCRIPTION
Refs: #221