### PR TITLE
feat: New version option --auto-height

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,9 @@ pub struct VersionCommand {
     /// Print the commit-sha of the version instead of the semantic version
     #[clap(long)]
     pub commit_sha: bool,
+    /// Use the height since the latest tag when creating pre-release labels
+    #[clap(long)]
+    pub auto_height: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -310,6 +310,7 @@ impl ChangelogCommand {
         )?;
         match helper
             .find_last_version(rev)
+            .map(|vh| vh.map(|v| v.version))
             .with_context(|| format!("Could not find the last version for revision {rev}"))?
         {
             Some(last_version) => {

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -141,11 +141,12 @@ impl VersionCommand {
         types: Vec<Type>,
     ) -> Result<(Version, Label, String), Error> {
         if let Some(VersionAndHeight {
-            version: VersionAndTag {
-                tag,
-                mut version,
-                commit_sha,               
-            },
+            version:
+                VersionAndTag {
+                    tag,
+                    mut version,
+                    commit_sha,
+                },
             height,
         }) = self.find_last_version()?
         {

--- a/src/git.rs
+++ b/src/git.rs
@@ -69,14 +69,15 @@ impl GitHelper {
         let last_version = version.first().cloned().cloned();
 
         let mut result: Option<VersionAndHeight> = None;
-        if let Some(last_version) = last_version.clone() {   
+        if let Some(last_version) = last_version.clone() {
             let mut revwalk_height = self.repo.revwalk()?;
-            revwalk_height.push_range(format!("{}..{}", last_version.commit_sha, rev.id()).as_str())?;
+            revwalk_height
+                .push_range(format!("{}..{}", last_version.commit_sha, rev.id()).as_str())?;
             revwalk_height.simplify_first_parent()?;
             let height = revwalk_height.flatten().count();
             result = Some(VersionAndHeight {
                 version: last_version,
-                height: height,
+                height,
             });
         }
 

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -49,9 +49,10 @@ impl SemVer {
         self.0.pre = Prerelease::EMPTY
     }
 
-    pub fn increment_prerelease(&mut self, prerelease: &Prerelease) {
+    pub fn increment_prerelease(&mut self, prerelease: &Prerelease, height: Option<usize>) {
         if self.0.pre.is_empty() {
-            self.0.pre = Prerelease::new(format!("{prerelease}.1").as_str()).unwrap();
+            let h = height.unwrap_or(1);
+            self.0.pre = Prerelease::new(format!("{prerelease}.{h}").as_str()).unwrap();
         } else {
             let next = self
                 .0


### PR DESCRIPTION
A proposed feature to autocalculate the numeric value of a pre-release label using the shortest distance to the latest version tag.  This is enabled using `convco version --bump --prerelease label --auto-height`.

This facilitates ensuring each commit of a pre-release (which I use for feature branches) gets a meaningful version without needing to tag those commits.  Tagging commits on a feature branch, before deleting the branch during merge, would lead to those commits becoming headless.

I'm happy for this to be rejected if it is out of scope for this project