### PR TITLE
feat(commit): adds configuration options for the minumum and maximum …

### DIFF
--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -89,12 +89,20 @@ fn read_scope(
 fn read_description(
     theme: &impl dialoguer::theme::Theme,
     default: String,
+    min_length: usize,
+    max_length: usize,
 ) -> Result<String, Error> {
     let result: String = dialoguer::Input::with_theme(theme)
         .with_prompt("description")
         .validate_with(|input: &String| {
-            if input.len() < 10 {
-                Err("Description needs a length of at least 10 characters")
+            if input.len() < min_length {
+                Err(format!(
+                    "Description needs a length of at least {min_length} characters"
+                ))
+            } else if input.len() > max_length {
+                Err(format!(
+                    "Description needs a length of at most {max_length} characters"
+                ))
             } else {
                 Ok(())
             }
@@ -220,7 +228,12 @@ impl Dialog {
             .unwrap();
             self.r#type = Self::select_type(theme, self.r#type.as_str(), types)?;
             self.scope = read_scope(theme, self.scope.as_str(), scope_regex)?;
-            self.description = read_description(theme, self.description.clone())?;
+            self.description = read_description(
+                theme,
+                self.description.clone(),
+                config.description.length.min.unwrap_or(0),
+                config.description.length.max.unwrap_or(usize::MAX),
+            )?;
             self.body = format!("{}\n{}", self.body, BODY_MSG);
             self.breaking_change = read_single_line(
                 theme,

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -102,6 +102,31 @@ pub(crate) struct Config {
     /// Strip the commit message(s) by the given regex pattern
     #[serde(default = "default_strip_regex")]
     pub(crate) strip_regex: String,
+    #[serde(default)]
+    pub(crate) description: DescriptionConfig,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+pub(crate) struct DescriptionConfig {
+    pub(crate) length: DescriptionLengthConfig,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DescriptionLengthConfig {
+    /// Define the minimum length of the description when using convco commit
+    #[serde(default = "default_some_10")]
+    pub(crate) min: Option<usize>,
+    /// Define the maximum length of the description when using convco commit
+    pub(crate) max: Option<usize>,
+}
+
+impl Default for DescriptionLengthConfig {
+    fn default() -> Self {
+        Self {
+            min: Some(10),
+            max: None,
+        }
+    }
 }
 
 fn deserialize_type<'de, D>(deserializer: D) -> Result<Vec<Type>, D::Error>
@@ -145,6 +170,10 @@ const fn default_true() -> bool {
     true
 }
 
+const fn default_some_10() -> Option<usize> {
+    Some(10)
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -170,6 +199,7 @@ impl Default for Config {
             first_parent: false,
             wrap_disabled: false,
             strip_regex: "".to_string(),
+            description: Default::default(),
         }
     }
 }
@@ -508,6 +538,7 @@ mod tests {
                 first_parent: false,
                 wrap_disabled: false,
                 strip_regex: "".to_string(),
+                description: DescriptionConfig { length: DescriptionLengthConfig { min: Some(10), max: None } }
             }
         )
     }


### PR DESCRIPTION
…length of the description

Introduces configuration options for the commit description length.

Example `.convco` config file:

```yaml
description:
  length:
    min: 0
    max: 75
```

Refs: #227