### PR TITLE
feat: Use FuzzySelect for selecting type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "thiserror",
@@ -336,6 +337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -820,6 +830,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.60" # for `--features`
 anyhow = { version = "1.0.81", features = ["backtrace"] }
 clap = { version = "4.5.7", features = ["derive", "env"] }
 ctrlc = "3.4.4"
-dialoguer = "0.11.0"
+dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 git2 = { version = "0.19.0", default-features = false }
 handlebars = "6.0.0"
 regex = "1.10.4"

--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -183,7 +183,7 @@ impl Dialog {
         selected: &str,
         types: &[Type],
     ) -> Result<String, Error> {
-        let index = dialoguer::Select::with_theme(theme)
+        let index = dialoguer::FuzzySelect::with_theme(theme)
             .with_prompt("type")
             .items(types)
             .default(types.iter().position(|t| t.r#type == selected).unwrap_or(0))


### PR DESCRIPTION
This PR changes the `dialoguer::Select` to `dialoguer::FuzzySelect` and enables the `fuzzy-select` feature. 

The rationale for this change is to allow quicker developer workflow by allowing the developer to type the partial commit type and quickly select it without taking the hands off his keyboard to use the arrow keys.

This change shouldn't brake any current developer workflows, since the commit type can still be selected using the arrow keys.