### PR TITLE
feat: allow to ignore prereleases when determining the last version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,9 @@ pub struct VersionCommand {
     /// Print the commit-sha of the version instead of the semantic version
     #[clap(long)]
     pub commit_sha: bool,
+    /// Ignore pre-release versions when finding the last version
+    #[clap(long, env = "CONVCO_IGNORE_PRERELEASES")]
+    pub ignore_prereleases: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -121,6 +124,9 @@ pub struct ChangelogCommand {
     /// Only show this number of patch versions.
     #[clap(long, default_value_t=u64::MAX, hide_default_value=true, env = "CONVCO_MAX_PATCHES")]
     pub max_patches: u64,
+    /// Ignore pre-release versions when finding the last version
+    #[clap(long, env = "CONVCO_IGNORE_PRERELEASES")]
+    pub ignore_prereleases: bool,
     /// Do not generate links. Overrides linkReferences and linkCompare in the config.
     #[clap(short, long, env = "CONVCO_NO_LINKS")]
     pub no_links: bool,

--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -309,7 +309,7 @@ impl ChangelogCommand {
             &self.prefix,
         )?;
         match helper
-            .find_last_version(rev)
+            .find_last_version(rev, self.ignore_prereleases)
             .with_context(|| format!("Could not find the last version for revision {rev}"))?
         {
             Some(last_version) => {

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -43,7 +43,10 @@ impl VersionCommand {
     /// returns the versions under the given rev
     fn find_last_version(&self) -> Result<Option<VersionAndTag>, Error> {
         let prefix = self.prefix.as_str();
-        Ok(GitHelper::new(prefix)?.find_last_version(self.rev.as_str())?)
+        Ok(
+            GitHelper::new(prefix)?
+                .find_last_version(self.rev.as_str(), self.ignore_prereleases)?,
+        )
     }
 
     /// Find the bump version based on the conventional commit types.


### PR DESCRIPTION
To ignore prerelease tags on the PR branches when compiling the final changelog after the merge, this allows to ignore prerelease tags entirely.