### PR TITLE
feat!: link to commit hash instead of HEAD in compareUrl

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -228,6 +228,14 @@ impl<'a> ChangeLogTransformer<'a> {
             .map(|(title, notes)| NoteGroup { title, notes })
             .collect();
 
+        let current_tag = if from_rev.0 == "HEAD" {
+            let id = self.git.ref_to_commit("HEAD")?.id();
+
+            id.to_string()
+        } else {
+            from_rev.0.to_owned()
+        };
+
         let context_base = ContextBase {
             version,
             date: Some(version_date),
@@ -235,7 +243,7 @@ impl<'a> ChangeLogTransformer<'a> {
             commit_groups,
             note_groups,
             previous_tag: to_rev.0,
-            current_tag: from_rev.0,
+            current_tag: current_tag.into(),
             host: host.to_owned(),
             owner: owner.to_owned(),
             repository: repository.to_owned(),

--- a/src/conventional/changelog.rs
+++ b/src/conventional/changelog.rs
@@ -79,7 +79,7 @@ pub(crate) struct ContextBase<'a> {
     pub(crate) commit_groups: Vec<CommitGroup<'a>>,
     pub(crate) note_groups: Vec<NoteGroup>,
     pub(crate) previous_tag: &'a str,
-    pub(crate) current_tag: &'a str,
+    pub(crate) current_tag: Cow<'a, str>,
     pub(crate) host: Option<String>,
     pub(crate) owner: Option<String>,
     pub(crate) repository: Option<String>,


### PR DESCRIPTION
The current implementation links to compare URLs that refer to `HEAD`. This is not useful (in our case) as the content of this will change with future commits and does not reflect the state at the time of changelog generation.

I am not sure if there are use cases where the links using `HEAD` are meaningful. Do you want me to add an option to enable resolving to the commit ID or should this be the default/only option?