### PR TITLE
fix(version): do not ignore prerelease flag if no versions exist

### DIFF
--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -183,14 +183,26 @@ impl VersionCommand {
             let git = GitHelper::new(prefix)?;
             let commit_sha = git.ref_to_commit(&self.rev)?;
             let commit_sha = commit_sha.id().to_string();
-            if self.bump || self.minor {
-                Ok(("0.1.0".parse()?, Label::Minor, commit_sha))
-            } else if self.major {
-                Ok(("1.0.0".parse()?, Label::Major, commit_sha))
+            let mut version = Version::new(0, 0, 0);
+            if self.bump {
+                version.minor = 1;
+                if self.prerelease.is_empty() {
+                    Ok((version, Label::Minor, commit_sha))
+                } else {
+                    version.pre = self.prerelease.clone();
+                    Ok((version, Label::Prerelease, commit_sha))
+                }
             } else if self.patch {
-                Ok(("0.0.1".parse()?, Label::Patch, commit_sha))
+                version.patch = 1;
+                Ok((version, Label::Patch, commit_sha))
+            } else if self.minor {
+                version.minor = 1;
+                Ok((version, Label::Minor, commit_sha))
+            } else if self.major {
+                version.major = 1;
+                Ok((version, Label::Major, commit_sha))
             } else {
-                Ok(("0.0.0".parse()?, Label::Patch, commit_sha))
+                Ok((version, Label::Patch, commit_sha))
             }
         }
     }


### PR DESCRIPTION
Before this change version 0.1.0 could not have a prerelease label.