### PR TITLE
fix(version): after a rebase a prerelease version should still increment

### DIFF
--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -131,6 +131,10 @@ impl VersionCommand {
             _ => Label::Release,
         };
         if !self.prerelease.is_empty() {
+            let prerelease = git.find_last_prerelease(&last_version, &self.prerelease);
+            if let Some(prerelease) = prerelease {
+                last_version.0.pre = prerelease;
+            }
             last_version.increment_prerelease(&self.prerelease);
         }
         Ok((last_version.0, label, commit_sha.unwrap_or_default()))

--- a/src/git.rs
+++ b/src/git.rs
@@ -123,6 +123,30 @@ impl GitHelper {
             .map(|diff| diff_updates_any_path(&diff, paths))
             .unwrap_or(false)
     }
+
+    pub(crate) fn find_last_prerelease(
+        &self,
+        last_version: &SemVer,
+        prerelease: &semver::Prerelease,
+    ) -> Option<semver::Prerelease> {
+        self.version_map
+            .values()
+            .flat_map(|vat| vat.iter())
+            .map(|vat| &vat.version.0)
+            .filter(|version| {
+                version.major == last_version.major()
+                    && version.minor == last_version.minor()
+                    && version.patch == last_version.patch()
+            })
+            .find(|version| {
+                version
+                    .pre
+                    .rsplit_once('.')
+                    .filter(|pre| prerelease.as_str() == pre.0)
+                    .is_some()
+            })
+            .map(|v| v.pre.clone())
+    }
 }
 
 pub(crate) fn filter_merge_commits(commit: &git2::Commit, merges: bool) -> bool {


### PR DESCRIPTION
Before if a tag was made on a branch that has been rebased later the bumped version for a new prerelease did conflict with the previous tag.

Here is an example of a commit graph where it went wrong. Now convco would print 1.1.0-rc.2

    ❯ git log --oneline --decorate --all --graph
    * 6d8cd28 (HEAD -> rc) feat: release 1.1.0
    *   3a9f9f0 (tag: v1.0.1, main) Merge branch 'hotfix'
    |\
    | * ae61e0e (tag: v1.0.1-hotfix.1, hotfix) fix: release 1.0.1-hotfix
    |/
    | * bb3fed9 (tag: v1.1.0-rc.1) feat: release 1.1.0
    |/
    * e4808fe (tag: v1.0.0) feat: release 1.0.0

    ❯ convco version
    1.0.1

    ❯ convco version --bump --prerelease rc
    1.1.0-rc.1

Refs: #264