### PR TITLE
feat: Find matching prerelease before bumping a new one

### DIFF
--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -130,14 +130,21 @@ impl VersionCommand {
             // TODO what should be the behaviour? always increment patch? or stay on same version?
             _ => Label::Release,
         };
+        let commit_sha = commit_sha.unwrap_or_default();
         if !self.prerelease.is_empty() {
-            let prerelease = git.find_last_prerelease(&last_version, &self.prerelease);
-            if let Some(prerelease) = prerelease {
+            if let Some(prerelease) =
+                git.find_matching_prerelease(&last_version, &self.prerelease, &commit_sha)
+            {
                 last_version.0.pre = prerelease;
+            } else {
+                let prerelease = git.find_last_prerelease(&last_version, &self.prerelease);
+                if let Some(prerelease) = prerelease {
+                    last_version.0.pre = prerelease;
+                }
+                last_version.increment_prerelease(&self.prerelease);
             }
-            last_version.increment_prerelease(&self.prerelease);
         }
-        Ok((last_version.0, label, commit_sha.unwrap_or_default()))
+        Ok((last_version.0, label, commit_sha))
     }
 
     fn get_version(

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -43,10 +43,10 @@ impl VersionCommand {
     /// returns the versions under the given rev
     fn find_last_version(&self) -> Result<Option<VersionAndTag>, Error> {
         let prefix = self.prefix.as_str();
-        Ok(
-            GitHelper::new(prefix)?
-                .find_last_version(self.rev.as_str(), self.ignore_prereleases)?,
-        )
+        let ignore_prereleases = // When bumping always ignore prereleases
+            self.bump ||
+            self.ignore_prereleases;
+        Ok(GitHelper::new(prefix)?.find_last_version(self.rev.as_str(), ignore_prereleases)?)
     }
 
     /// Find the bump version based on the conventional commit types.

--- a/src/git.rs
+++ b/src/git.rs
@@ -349,9 +349,9 @@ mod tests {
                 (
                     Oid::from_str("0003").unwrap(),
                     vec![VersionAndTag {
-                        tag: "v1.2.3-rc.3".to_string(),
-                        version: SemVer(Version::parse("1.2.3-rc.3").unwrap()),
-                        commit_sha: "0003".to_string(),
+                        tag: "v1.2.3-beta.1".to_string(),
+                        version: SemVer(Version::parse("1.2.3-beta.1").unwrap()),
+                        commit_sha: "0004".to_string(),
                     }],
                 ),
                 (


### PR DESCRIPTION
Closes #284 

In order to do not re-tag prerelease for the same channel referencing the same commit.

I created a new function `find_last_prerelease` in `git.rs`, but changing `find_last_prerelease` could be a good solution too.

Let me know if you prefer another implementation.