### PR TITLE
feat(version): allow setting the initial version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,9 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ git2 = { version = "0.20.0", default-features = false }
 handlebars = "6.3.0"
 jiff = { version = "0.1.21", features = ["serde"] }
 regex = "1.11.1"
-semver = "1.0.24"
+semver = { version = "1.0.24", features = ["serde"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_norway = "0.9.42"
 thiserror = "2.0.9"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, str::FromStr};
 use clap::Parser;
 #[cfg(feature = "completions")]
 use clap_complete::aot::Shell as Shells;
-use semver::Prerelease;
+use semver::{Prerelease, Version};
 
 #[derive(Debug, Parser)]
 #[clap(name = "convco", about = "Conventional commit tools", version)]
@@ -80,6 +80,9 @@ pub struct VersionCommand {
     /// Ignore pre-release versions when finding the last version
     #[clap(long, env = "CONVCO_IGNORE_PRERELEASES")]
     pub ignore_prereleases: bool,
+    /// If no version is found use this version for the first bump
+    #[clap(long, env = "CONVCO_INITIAL_BUMP_VERSION")]
+    pub initial_bump_version: Option<Version>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
@@ -104,6 +105,13 @@ pub(crate) struct Config {
     pub(crate) strip_regex: String,
     #[serde(default)]
     pub(crate) description: DescriptionConfig,
+    /// Initial version to use if no previous version is found
+    #[serde(default = "default_initial_bump_version")]
+    pub(crate) initial_bump_version: Version,
+}
+
+fn default_initial_bump_version() -> Version {
+    Version::new(0, 1, 0)
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -200,6 +208,7 @@ impl Default for Config {
             wrap_disabled: false,
             strip_regex: "".to_string(),
             description: Default::default(),
+            initial_bump_version: Version::new(0, 1, 0),
         }
     }
 }
@@ -538,7 +547,8 @@ mod tests {
                 first_parent: false,
                 wrap_disabled: false,
                 strip_regex: "".to_string(),
-                description: DescriptionConfig { length: DescriptionLengthConfig { min: Some(10), max: None } }
+                description: DescriptionConfig { length: DescriptionLengthConfig { min: Some(10), max: None } },
+                initial_bump_version: Version::new(0, 1, 0),
             }
         )
     }


### PR DESCRIPTION
To set the initial version for `convco version --bump` to something else than 0.1.0. Use `convco version --initial-bump-version 1.0.0` or set it using the environment variable `CONVCO_INITIAL_BUMP_VERSION`. It can also be added to the configuration under `initialBumpVersion`.

Refs: #290