### PR TITLE
feat(version): add env variable for --major, --minor and --patch options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,13 +59,13 @@ pub struct VersionCommand {
     #[clap(short, long, conflicts_with_all(&["major", "minor", "patch"]))]
     pub label: bool,
     /// Bump to a major release version, regardless of the conventional commits
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_FORCE_MAJOR_BUMP")]
     pub major: bool,
     /// Bump to a minor release version, regardless of the conventional commits
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_FORCE_MINOR_BUMP")]
     pub minor: bool,
     /// Bump to a patch release version, regardless of the conventional commits
-    #[clap(long)]
+    #[clap(long, env = "CONVCO_FORCE_PATCH_BUMP")]
     pub patch: bool,
     /// Suffix with a prerelease version. Requires --bump.
     #[clap(long, requires = "bump", default_value_t = Prerelease::new("").unwrap())]


### PR DESCRIPTION
Added env variables to accompany the following cli options:

- `--major` => `CONVCO_FORCE_MAJOR_BUMP`
- `--minor` => `CONVCO_FORCE_MINOR_BUMP`
- `--patch` => `CONVCO_FORCE_PATCH_BUMP`

closes #319