### PR TITLE
feat: add `did you mean` fuzzy error for `convco check`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_norway",
+ "strsim",
  "thiserror 2.0.12",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "2.0.12"
 url = "2.5.4"
 walkdir = "2.5.0"
 clap_complete = { version = "4.5.47", optional = true }
+strsim = "0.11.1"
 
 [build-dependencies]
 clap_complete = "4.5.47"


### PR DESCRIPTION
closes #359 

Notes: I'm not sure if changing error format is considered a breaking change. I retained the existing error text verbatim in case anyone is grepping for it. I also only am showing the best single suggestion in order to keep the error message concise, since the existing format needs it to fit onto a single line