### PR TITLE
fix(commit): add an empty line between the description and body

### DIFF
--- a/src/conventional/commit/message.hbs
+++ b/src/conventional/commit/message.hbs
@@ -1,4 +1,5 @@
 {{type}}{{#if scope}}({{scope}}){{/if}}{{#if breaking}}!{{/if}}: {{description}}
+
 {{body}}
 {{#if breaking_change}}BREAKING CHANGE: {{breaking_change}}{{/if}}
 


### PR DESCRIPTION
This to be in line with the spec.

> A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.

Refs: #367