### PR TITLE
feat: add support to ignore-paths for both version and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ It is inspired by [conventional changelog][2] and the [configuration file](#conf
 convco changelog > CHANGELOG.md
 ```
 
+To ignore commits that only touch certain paths, use `--ignore-path` (repeatable):
+
+```sh
+convco changelog --ignore-path docs --ignore-path .github > CHANGELOG.md
+```
+
 ### Check
 
 Check a range of revisions for compliance.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ If needed one can provide `--major`, `--minor` or `--patch` to overrule the conv
 convco version --bump
 ```
 
+You can ignore commits that only touch certain paths (e.g. docs or CI config):
+
+```sh
+convco version --bump --ignore-path docs --ignore-path .github
+```
+
+The equivalent configuration key is `ignore_paths`.
+
 It is useful to use it with release tools, such as [`cargo-release`](https://crates.io/crates/cargo-release):
 
 ```sh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,10 @@ pub struct VersionCommand {
     /// Each path should be relative to the root of the repository.
     #[clap(short = 'P', long, env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
+    /// Ignore commits that update only those <paths> when calculating the bumped version.
+    /// Each path should be relative to the root of the repository.
+    #[clap(long = "ignore-path", visible_alias = "ignore-paths", env = "CONVCO_IGNORE_PATHS")]
+    pub ignore_paths: Vec<PathBuf>,
     /// Print the commit-sha of the version instead of the semantic version
     #[clap(long)]
     pub commit_sha: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,10 @@ pub struct ChangelogCommand {
     /// Each path should be relative to the root of the repository.
     #[clap(short = 'P', long, env = "CONVCO_PATHS")]
     pub paths: Vec<PathBuf>,
+    /// Ignore commits that update only those <paths>.
+    /// Each path should be relative to the root of the repository.
+    #[clap(long = "ignore-path", visible_alias = "ignore-paths", env = "CONVCO_IGNORE_PATHS")]
+    pub ignore_paths: Vec<PathBuf>,
     /// Follow only the first parent of merge commits. Commits from the merged branche(s) will be discarded.
     #[clap(long, env = "CONVCO_FIRST_PARENT")]
     pub first_parent: bool,

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -108,6 +108,10 @@ pub(crate) struct Config {
     /// Initial version to use if no previous version is found
     #[serde(default = "default_initial_bump_version")]
     pub(crate) initial_bump_version: Version,
+    /// Ignore commits that update only those paths when calculating bumped versions.
+    /// Each path should be relative to the root of the repository.
+    #[serde(default, alias = "ignore_paths", alias = "ignore-paths")]
+    pub(crate) ignore_paths: Vec<PathBuf>,
 }
 
 fn default_initial_bump_version() -> Version {
@@ -209,6 +213,7 @@ impl Default for Config {
             strip_regex: "".to_string(),
             description: Default::default(),
             initial_bump_version: Version::new(0, 1, 0),
+            ignore_paths: Vec::new(),
         }
     }
 }
@@ -549,6 +554,7 @@ mod tests {
                 strip_regex: "".to_string(),
                 description: DescriptionConfig { length: DescriptionLengthConfig { min: Some(10), max: None } },
                 initial_bump_version: Version::new(0, 1, 0),
+                ignore_paths: Vec::new(),
             }
         )
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, collections::HashMap, path::PathBuf};
 
-use git2::{Commit, Diff, Error, Object, Oid, Repository, Revwalk};
+use git2::{Commit, Error, Object, Oid, Repository, Revwalk};
 use semver::Version;
 
 use crate::semver::SemVer;
@@ -109,19 +109,6 @@ impl GitHelper {
             .find_remote("origin")?
             .url()
             .map(|s| s.to_string()))
-    }
-
-    pub(crate) fn commit_updates_any_path(&self, commit: &Commit, paths: &[PathBuf]) -> bool {
-        if paths.is_empty() {
-            return true;
-        }
-
-        let tree = commit.tree().ok();
-        let parent_tree = commit.parent(0).and_then(|item| item.tree()).ok();
-        self.repo
-            .diff_tree_to_tree(parent_tree.as_ref(), tree.as_ref(), None)
-            .map(|diff| diff_updates_any_path(&diff, paths))
-            .unwrap_or(false)
     }
 
     /// Returns true if a commit should be considered relevant based on include/ignore path filters.
@@ -284,26 +271,6 @@ fn object_to_target_commit_id(obj: Object<'_>) -> Oid {
     } else {
         obj.id()
     }
-}
-
-fn diff_updates_any_path(diff: &Diff, paths: &[PathBuf]) -> bool {
-    let mut update_any_path = false;
-
-    diff.foreach(
-        &mut |delta, _progress| {
-            if let Some(file) = delta.new_file().path() {
-                update_any_path |= paths.iter().any(|path| file.starts_with(path));
-            }
-
-            !update_any_path
-        },
-        None,
-        None,
-        None,
-    )
-    .ok();
-
-    update_any_path
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request adds support for ignoring commits that only affect specified paths (such as documentation or CI config) when generating changelogs or calculating version bumps. This feature is exposed via a new `--ignore-path` command-line option (and corresponding config key), and is integrated into both the changelog and version subcommands. The implementation introduces a new filtering function that considers both include and ignore path lists, and updates the CLI, configuration, and documentation accordingly.

**New ignore paths feature:**

* Added a `--ignore-path` (repeatable) option to both the `changelog` and `version` commands, allowing users to specify paths to ignore when determining relevant commits. This is also supported via the `ignore_paths` configuration key. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R146-R153); `src/cli.rs` [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR77-R80) [[4]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR162-R165); `src/conventional/config.rs` [[5]](diffhunk://#diff-7e1527026b13d18c6db5943a64a0612698b938f7c01392e00a407532ee13e628R111-R114) [[6]](diffhunk://#diff-7e1527026b13d18c6db5943a64a0612698b938f7c01392e00a407532ee13e628R216) [[7]](diffhunk://#diff-7e1527026b13d18c6db5943a64a0612698b938f7c01392e00a407532ee13e628R557)

* Updated the changelog and version command implementations to honor the ignore paths option and config, falling back to config if the CLI flag is not set. (`src/cmd/changelog.rs` [[1]](diffhunk://#diff-1d4dc03a13e7f319e7d1ef9941d811a79fce5eff3d508d7722568fb4d42c417eR50) [[2]](diffhunk://#diff-1d4dc03a13e7f319e7d1ef9941d811a79fce5eff3d508d7722568fb4d42c417eR69) [[3]](diffhunk://#diff-1d4dc03a13e7f319e7d1ef9941d811a79fce5eff3d508d7722568fb4d42c417eR106) [[4]](diffhunk://#diff-1d4dc03a13e7f319e7d1ef9941d811a79fce5eff3d508d7722568fb4d42c417eR286-R290) [[5]](diffhunk://#diff-1d4dc03a13e7f319e7d1ef9941d811a79fce5eff3d508d7722568fb4d42c417eR332); `src/cmd/version.rs` [[6]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2R69) [[7]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2L77-R78) [[8]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2R166) [[9]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2L196-R198) [[10]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2R250-R254) [[11]](diffhunk://#diff-61efd03eae474153bd04350273f927108ffd96dea9634a636e46c6e604568ed2R264)

**Commit filtering logic:**

* Introduced a new `commit_updates_relevant_paths` method in `GitHelper` that filters commits based on both include and ignore paths, replacing the previous `commit_updates_any_path` logic. This ensures commits are only considered if they touch relevant files and not just ignored paths. (`src/git.rs` [src/git.rsL114-R171](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L114-R171))

* Removed the now-obsolete `diff_updates_any_path` helper function, as its logic is subsumed by the new filtering method. (`src/git.rs` [src/git.rsL229-L248](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L229-L248))

**Documentation:**

* Updated the `README.md` to document the new `--ignore-path` option and its usage in both changelog and version commands. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R146-R153)