### PR TITLE
feat(check): add ignore_message_pattern to filter commits by regex

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,9 @@ pub struct CheckCommand {
     /// Ignore commits created by `git revert` commands
     #[clap(long, env = "CONVCO_IGNORE_REVERTS")]
     pub ignore_reverts: bool,
+    /// Ignore commits whose message matches the given regex pattern
+    #[clap(long, env = "CONVCO_IGNORE_MESSAGE_PATTERN")]
+    pub ignore_message_pattern: Vec<String>,
     /// Read a single commit message from stdin
     #[clap(long)]
     pub from_stdin: bool,

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -6,12 +6,13 @@ use std::{
 
 use conventional::Config;
 use git2::Repository;
+use regex::RegexSet;
 
 use crate::{
     cli::CheckCommand,
     cmd::Command,
     conventional,
-    git::{filter_merge_commits, filter_revert_commits},
+    git::{filter_merge_commits, filter_message_pattern, filter_revert_commits},
     strip::Strip,
     Error,
 };
@@ -110,6 +111,14 @@ impl Command for CheckCommand {
 
         let Config { merges, .. } = config;
 
+        // Use CLI patterns if provided, otherwise use config patterns
+        let ignore_patterns = if self.ignore_message_pattern.is_empty() {
+            &config.ignore_message_pattern
+        } else {
+            &self.ignore_message_pattern
+        };
+        let ignore_patterns = RegexSet::new(ignore_patterns).map_err(Error::from)?;
+
         if self.from_stdin {
             let mut stdin = stdin().lock();
             let mut commit_msg = String::new();
@@ -146,6 +155,7 @@ impl Command for CheckCommand {
             .flat_map(|oid| repo.find_commit(oid).ok())
             .filter(|commit| filter_merge_commits(commit, merges))
             .filter(|commit| filter_revert_commits(commit, self.ignore_reverts))
+            .filter(|commit| filter_message_pattern(commit, &ignore_patterns))
             .take(self.number.unwrap_or(std::usize::MAX))
         {
             total += 1;

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -108,6 +108,9 @@ pub(crate) struct Config {
     /// Initial version to use if no previous version is found
     #[serde(default = "default_initial_bump_version")]
     pub(crate) initial_bump_version: Version,
+    /// Ignore commits whose message matches any of the given regex patterns
+    #[serde(default)]
+    pub(crate) ignore_message_pattern: Vec<String>,
 }
 
 fn default_initial_bump_version() -> Version {
@@ -209,6 +212,7 @@ impl Default for Config {
             strip_regex: "".to_string(),
             description: Default::default(),
             initial_bump_version: Version::new(0, 1, 0),
+            ignore_message_pattern: vec![],
         }
     }
 }
@@ -549,6 +553,7 @@ mod tests {
                 strip_regex: "".to_string(),
                 description: DescriptionConfig { length: DescriptionLengthConfig { min: Some(10), max: None } },
                 initial_bump_version: Version::new(0, 1, 0),
+                ignore_message_pattern: vec![],
             }
         )
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub(crate) enum Error {
     SemVer(#[from] semver::Error),
     #[error(transparent)]
     Yaml(#[from] serde_norway::Error),
+    #[error(transparent)]
+    Regex(#[from] regex::Error),
     #[error("check error")]
     Check,
     #[error("wrong type: {wrong_type}")]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, collections::HashMap, path::PathBuf};
 
 use git2::{Commit, Diff, Error, Object, Oid, Repository, Revwalk};
+use regex::RegexSet;
 use semver::Version;
 
 use crate::semver::SemVer;
@@ -197,6 +198,13 @@ pub(crate) fn filter_revert_commits(commit: &git2::Commit, ignore_reverts: bool)
     true
 }
 
+pub(crate) fn filter_message_pattern(commit: &git2::Commit, patterns: &RegexSet) -> bool {
+    commit
+        .message()
+        .map(|m| !patterns.is_match(m))
+        .unwrap_or(true)
+}
+
 /// Build a hashmap that contains Commit `Oid` as key and a vector of `Version` as value.
 /// Can be used to easily walk a graph and check if it is a version.
 fn make_oid_version_map(repo: &Repository, prefix: &str) -> HashMap<Oid, Vec<VersionAndTag>> {
@@ -249,6 +257,42 @@ fn diff_updates_any_path(diff: &Diff, paths: &[PathBuf]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_filter_message_pattern_none() {
+        let git_helper = GitHelper {
+            repo: Repository::open(".").unwrap(),
+            version_map: HashMap::new(),
+        };
+        let commit = git_helper.repo.head().unwrap().peel_to_commit().unwrap();
+        let patterns = RegexSet::new([] as [&str; 0]).unwrap();
+        assert!(filter_message_pattern(&commit, &patterns));
+    }
+
+    #[test]
+    fn test_filter_message_pattern_match() {
+        let git_helper = GitHelper {
+            repo: Repository::open(".").unwrap(),
+            version_map: HashMap::new(),
+        };
+        let commit = git_helper.repo.head().unwrap().peel_to_commit().unwrap();
+        let patterns = RegexSet::new(["^Initial commit$"]).unwrap();
+        let result = filter_message_pattern(&commit, &patterns);
+        // Result depends on actual commit message
+        // Just ensure it doesn't panic
+        let _ = result;
+    }
+
+    #[test]
+    fn test_filter_message_pattern_no_match() {
+        let git_helper = GitHelper {
+            repo: Repository::open(".").unwrap(),
+            version_map: HashMap::new(),
+        };
+        let commit = git_helper.repo.head().unwrap().peel_to_commit().unwrap();
+        let patterns = RegexSet::new(["^NEVER_MATCH_THIS_PATTERN$"]).unwrap();
+        assert!(filter_message_pattern(&commit, &patterns));
+    }
 
     #[test]
     fn test_find_last_unordered_prerelease() {


### PR DESCRIPTION
Adds a configurable regex pattern to ignore commits matching specific message patterns during convco check.

Usage with cli flag: `convco check --ignore-message-pattern '^Initial commit$'` or set in config `ignoreMessagePattern = '^Initial commit$'`.

Refs: #397