### PR TITLE
chore(ci): build x86_64 linux binary as static musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
               name: ubuntu
               version: latest
             binary: convco
+            target: x86_64-unknown-linux-musl
           - os:
               name: ubuntu
               version: latest
@@ -55,8 +56,8 @@ jobs:
 
       - name: Build ${{ matrix.os.name }} binary
         run: |
-          cargo build --release
-          cargo install --root . --path .
+          cargo build --release ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+          cargo install --root . --path . ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
       - name: Upload ${{ matrix.os.name }} binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Hi,

Thanks for convco, I've been using it for years both locally and in my CI workflows.

While trying to add it to [taiki-e/install-action](https://github.com/taiki-e/install-action) in my PR https://github.com/taiki-e/install-action/pull/1831, I noticed an issue with the way the binary for linux x86-64 is built:

- You do install `musl-tools` and add the musl target
- But `cargo build` runs without `--target`, so the binary ends up as glibc-dynamic
- I'm pretty sure this was not your intent.

That's the only issue I could spot: ubuntu-24.04-arm is indeed musl.

Here's a little PR to fix this.

Thanks in advance
Cheers