### PR TITLE
fix: comply with the conventional commit spec regarding casing

### DIFF
--- a/src/cmd/changelog.rs
+++ b/src/cmd/changelog.rs
@@ -6,8 +6,8 @@ use convco::{
         ChangelogWriter, CommitContext, CommitGroup, Context, ContextBase, ContextBuilder, Note,
         NoteGroup, Reference,
     },
-    open_repo, CommitParser, CommitTrait, Config, ConvcoError, Footer, FooterKey, MaxMajorsIterExt,
-    MaxMinorsIterExt, MaxPatchesIterExt, Repo, RevWalkOptions,
+    commit_type_eq, open_repo, CommitParser, CommitTrait, Config, ConvcoError, Footer, FooterKey,
+    MaxMajorsIterExt, MaxMinorsIterExt, MaxPatchesIterExt, Repo, RevWalkOptions,
 };
 use semver::Version;
 
@@ -28,7 +28,7 @@ struct Unreleased {
 
 /// Transforms a range of commits to pass them to the changelog writer.
 struct ChangeLogTransformer<'a, R: Repo<'a>> {
-    group_types: HashMap<&'a str, &'a str>,
+    group_types: Vec<(&'a str, &'a str)>,
     config: &'a Config,
     revwalk_options: RevWalkOptions<'a, R::CommitTrait>,
     unreleased: Unreleased,
@@ -50,10 +50,8 @@ impl<'a, R: Repo<'a>> ChangeLogTransformer<'a, R> {
             .types
             .iter()
             .filter(|ty| include_hidden_sections || !ty.hidden)
-            .fold(HashMap::new(), |mut acc, ty| {
-                acc.insert(ty.r#type.as_str(), ty.section.as_str());
-                acc
-            });
+            .map(|ty| (ty.r#type.as_str(), ty.section.as_str()))
+            .collect();
 
         let context_builder = ContextBuilder::new(config)?;
         let unreleased = match unreleased.parse::<Version>() {
@@ -159,7 +157,11 @@ impl<'a, R: Repo<'a>> ChangeLogTransformer<'a, R> {
                 short_hash,
                 references,
             };
-            if let Some(section) = self.group_types.get(conv_commit.r#type.as_str()) {
+            if let Some((_, section)) = self
+                .group_types
+                .iter()
+                .find(|(ty, _)| commit_type_eq(ty, &conv_commit.r#type))
+            {
                 commits.entry(section).or_default().push(commit_context)
             }
         }

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use convco::{
-    open_repo, strip::Strip, Commit, CommitParser, CommitTrait, Config, ConvcoError, Repo,
-    RevWalkOptions,
+    commit_type_eq, open_repo, strip::Strip, Commit, CommitParser, CommitTrait, Config,
+    ConvcoError, Repo, RevWalkOptions,
 };
 use jiff::Zoned;
 use regex::RegexSet;
@@ -75,7 +75,10 @@ fn print_check<O: CommitTrait>(
         Ok(Commit {
             conventional_commit,
             commit: oid,
-        }) if !types.contains(&conventional_commit.r#type) => {
+        }) if !types
+            .iter()
+            .any(|ty| commit_type_eq(ty, &conventional_commit.r#type)) =>
+        {
             let message = oid
                 .commit_message()
                 .unwrap_or_else(|_| Cow::Owned(conventional_commit.description.clone()));

--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use convco::{
-    open_repo, strip::Strip, CommitParser, Config, ConvcoError, ParseError, Repo, RevWalkOptions,
-    Type,
+    commit_scope_eq, open_repo, strip::Strip, CommitParser, Config, ConvcoError, ParseError, Repo,
+    RevWalkOptions, Type,
 };
 use dialoguer::{BasicHistory, Completion, History};
 use handlebars::{no_escape, Handlebars};
@@ -107,8 +107,18 @@ struct ScopeCompletionState {
 
 impl ScopeCompletion {
     fn new(scopes: &[String]) -> Self {
+        let mut unique_scopes: Vec<String> = Vec::new();
+        for scope in scopes {
+            if !unique_scopes
+                .iter()
+                .any(|unique_scope| commit_scope_eq(unique_scope, scope))
+            {
+                unique_scopes.push(scope.clone());
+            }
+        }
+
         Self {
-            scopes: scopes.to_owned(),
+            scopes: unique_scopes,
             state: Mutex::new(None),
         }
     }
@@ -116,7 +126,12 @@ impl ScopeCompletion {
     fn matches(&self, input: &str) -> Vec<String> {
         self.scopes
             .iter()
-            .filter(|scope| scope.starts_with(input))
+            .filter(|scope| {
+                scope
+                    .get(..input.len())
+                    .map(|prefix| commit_scope_eq(prefix, input))
+                    .unwrap_or(false)
+            })
             .cloned()
             .collect()
     }
@@ -565,7 +580,7 @@ where
 
 fn push_scope(scopes: &mut Vec<String>, seen: &mut HashSet<String>, scope: Option<String>) {
     if let Some(scope) = scope {
-        if seen.insert(scope.clone()) {
+        if seen.insert(scope.to_ascii_lowercase()) {
             scopes.push(scope);
         }
     }
@@ -585,6 +600,21 @@ mod tests {
         let completion = ScopeCompletion::new(&["commit".into(), "changelog".into()]);
 
         assert_eq!(completion.get("com"), Some("commit".into()));
+    }
+
+    #[test]
+    fn scope_completion_matches_prefix_case_insensitively() {
+        let completion = ScopeCompletion::new(&["Parser".into()]);
+
+        assert_eq!(completion.get("pa"), Some("Parser".into()));
+    }
+
+    #[test]
+    fn scope_completion_deduplicates_case_variants() {
+        let completion = ScopeCompletion::new(&["Parser".into(), "parser".into()]);
+
+        assert_eq!(completion.get("pa"), Some("Parser".into()));
+        assert_eq!(completion.get("Parser"), Some("Parser".into()));
     }
 
     #[test]
@@ -668,5 +698,16 @@ mod tests {
         push_scope(&mut scopes, &mut seen, Some("commit".into()));
 
         assert_eq!(scopes, vec!["commit", "check"]);
+    }
+
+    #[test]
+    fn push_scope_deduplicates_case_variants_and_keeps_first_casing() {
+        let mut scopes = Vec::new();
+        let mut seen = HashSet::new();
+
+        push_scope(&mut scopes, &mut seen, Some("Parser".into()));
+        push_scope(&mut scopes, &mut seen, Some("parser".into()));
+
+        assert_eq!(scopes, vec!["Parser"]);
     }
 }

--- a/src/cmd/version.rs
+++ b/src/cmd/version.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use convco::{
-    open_repo, CommitParser, CommitTrait, Config, ConvcoError, Increment, Repo, RevWalkOptions,
-    Type,
+    commit_type_eq, open_repo, CommitParser, CommitTrait, Config, ConvcoError, Increment, Repo,
+    RevWalkOptions, Type,
 };
 use semver::{Prerelease, Version};
 
@@ -239,7 +239,7 @@ impl VersionCommand {
 
             let option_commit_type = types
                 .iter()
-                .find(|x| x.r#type == commit.conventional_commit.r#type);
+                .find(|x| commit_type_eq(&x.r#type, &commit.conventional_commit.r#type));
 
             if let Some(some_commit_type) = option_commit_type {
                 match (&some_commit_type.increment, major_version_zero) {

--- a/src/conventional/commit.rs
+++ b/src/conventional/commit.rs
@@ -404,6 +404,15 @@ mod tests {
     }
 
     #[test]
+    fn test_lowercase_breaking_change_footer_is_not_breaking() {
+        let msg = "feat: allow provided config object to extend other configs\n\
+                         \n\
+                         breaking change: `extends` key in config file is now used for extending other config files";
+        let conventional_commit: ConventionalCommit = parser().parse(msg).expect("valid");
+        assert!(!conventional_commit.is_breaking());
+    }
+
+    #[test]
     fn test_with_breaking_footer_newline() {
         let msg = "feat: allow provided config object to extend other configs\n\
                          \n\

--- a/src/conventional/config.rs
+++ b/src/conventional/config.rs
@@ -33,6 +33,14 @@ impl fmt::Display for Type {
     }
 }
 
+pub fn commit_type_eq(config_type: &str, commit_type: &str) -> bool {
+    config_type.eq_ignore_ascii_case(commit_type)
+}
+
+pub fn commit_scope_eq(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
+}
+
 /// see: [Conventional Changelog Configuration](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.1.0/README.md)
 /// Additional config: `host`, `owner`, `repository`, `scope_regex` and `template`
 /// Those values are derived from `git remote origin get-url` if not set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod strip;
 pub use conventional::{
     changelog,
     commit::{Footer, FooterKey},
-    config::{Increment, Type},
+    config::{commit_scope_eq, commit_type_eq, Increment, Type},
     CommitParser, Config, ParseError,
 };
 pub use error::ConvcoError;

--- a/tests/commands/changelog.rs
+++ b/tests/commands/changelog.rs
@@ -56,6 +56,74 @@ fn succeeds_on_conventional_commits() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[test]
+fn groups_default_types_case_insensitively() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["FEAT: uppercase feature"])?;
+    let repo = temp.path();
+
+    let output = run_convco_command(&["changelog", "--no-links"], Some(repo), true, "")?;
+
+    assert!(output.contains("### Features"), "got:\n{output}");
+    assert!(output.contains("uppercase feature"), "got:\n{output}");
+
+    Ok(())
+}
+
+#[test]
+fn preserves_scope_casing_in_output() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["feat(Parser): scoped feature"])?;
+    let repo = temp.path();
+
+    let output = run_convco_command(&["changelog", "--no-links"], Some(repo), true, "")?;
+
+    assert!(
+        output.contains("**Parser:** scoped feature"),
+        "got:\n{output}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn groups_custom_types_case_insensitively() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["CUSTOM: uppercase custom"])?;
+    let repo = temp.path();
+    fs::write(
+        repo.join(".convco"),
+        r#"types:
+- type: custom
+  section: Custom
+  hidden: false
+"#,
+    )?;
+
+    let output = run_convco_command(&["changelog", "--no-links"], Some(repo), true, "")?;
+
+    assert!(output.contains("### Custom"), "got:\n{output}");
+    assert!(output.contains("uppercase custom"), "got:\n{output}");
+
+    Ok(())
+}
+
+#[test]
+fn hidden_types_are_filtered_case_insensitively() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["DOCS: uppercase docs"])?;
+    let repo = temp.path();
+
+    let output = run_convco_command(&["changelog", "--no-links"], Some(repo), true, "")?;
+    assert!(!output.contains("uppercase docs"), "got:\n{output}");
+
+    let output = run_convco_command(
+        &["changelog", "--no-links", "--include-hidden-sections"],
+        Some(repo),
+        true,
+        "",
+    )?;
+    assert!(output.contains("uppercase docs"), "got:\n{output}");
+
+    Ok(())
+}
+
+#[test]
 fn non_linear_history_uses_highest_reachable_semver() -> Result<(), Box<dyn std::error::Error>> {
     let temp = setup_repo_with_non_linear_version_tags()?;
     let repo = temp.path();

--- a/tests/commands/check.rs
+++ b/tests/commands/check.rs
@@ -16,6 +16,34 @@ fn succeeds_on_conventional_commits() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[test]
+fn succeeds_on_case_insensitive_default_type() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["FEAT: uppercase feature"])?;
+    let repo = temp.path();
+
+    run_convco_command(&["check"], Some(repo), true, "")?;
+
+    Ok(())
+}
+
+#[test]
+fn succeeds_on_case_insensitive_custom_type() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["CUSTOM: uppercase custom"])?;
+    let repo = temp.path();
+    std::fs::write(
+        repo.join(".convco"),
+        r#"types:
+- type: custom
+  section: Custom
+  hidden: false
+"#,
+    )?;
+
+    run_convco_command(&["check"], Some(repo), true, "")?;
+
+    Ok(())
+}
+
+#[test]
 fn fails_on_non_conventional_commits() -> Result<(), Box<dyn std::error::Error>> {
     let temp = setup_repo_with_commits(&["this is not conventional"])?;
     let repo = temp.path();

--- a/tests/commands/version.rs
+++ b/tests/commands/version.rs
@@ -59,6 +59,55 @@ fn major_zero_default_bump_uses_pre_major_rules() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn bump_matches_default_types_case_insensitively() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["fix: base"])?;
+    let repo = temp.path();
+    git(repo, &["tag", "v1.0.0"])?;
+    git(
+        repo,
+        &["commit", "--allow-empty", "-m", "FEAT: uppercase feature"],
+    )?;
+
+    assert_version(repo, &["version", "--bump"], "1.1.0")?;
+
+    let temp = setup_repo_with_commits(&["feat: base"])?;
+    let repo = temp.path();
+    git(repo, &["tag", "v1.0.0"])?;
+    git(
+        repo,
+        &["commit", "--allow-empty", "-m", "FIX: uppercase fix"],
+    )?;
+
+    assert_version(repo, &["version", "--bump"], "1.0.1")?;
+
+    Ok(())
+}
+
+#[test]
+fn bump_matches_custom_type_case_insensitively() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = setup_repo_with_commits(&["fix: base"])?;
+    let repo = temp.path();
+    git(repo, &["tag", "v1.0.0"])?;
+    git(
+        repo,
+        &["commit", "--allow-empty", "-m", "CUSTOM: uppercase custom"],
+    )?;
+    fs::write(
+        repo.join(".convco"),
+        r#"types:
+- type: custom
+  increment: Patch
+  section: Custom
+  hidden: false
+"#,
+    )?;
+
+    assert_version(repo, &["version", "--bump"], "1.0.1")?;
+
+    Ok(())
+}
+
+#[test]
 fn major_zero_can_be_treated_as_stable_with_cli_flag() -> Result<(), Box<dyn std::error::Error>> {
     let temp = setup_major_zero_repo("feat: next")?;
     assert_version(


### PR DESCRIPTION
> The units of information that make up Conventional Commits MUST NOT be treated as case-sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.

Refs: #219